### PR TITLE
[14.0] edi_state: do not break when no origin set

### DIFF
--- a/edi_state_oca/models/edi_state_consumer_mixin.py
+++ b/edi_state_oca/models/edi_state_consumer_mixin.py
@@ -2,7 +2,11 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import logging
+
 from odoo import _, api, exceptions, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class EDIStateConsumerMixin(models.AbstractModel):
@@ -34,7 +38,9 @@ class EDIStateConsumerMixin(models.AbstractModel):
             return True
         # TODO: this implies we have `origin_exchange_type_id` from exchange.consumer.mixin
         exc_type = exc_type or self.origin_exchange_type_id
-        assert exc_type, f"No exchange type given for {self._name}#{self.id}"
+        if not exc_type:
+            _logger.warning("No exchange type given for %s#%s", self._name, self.id)
+            return True
         return (
             state.workflow_id.is_valid_for_model(self._name)
             and state.id in exc_type.state_workflow_ids.state_ids.ids

--- a/edi_state_oca/tests/test_edi_state.py
+++ b/edi_state_oca/tests/test_edi_state.py
@@ -89,6 +89,17 @@ class TestEDIState(EDIBackendCommonTestCase):
             self.consumer_record.edi_find_state(code="OK_1"), self.wf1_ok.state_ids[0]
         )
 
+    def test_mixin_edi_set_state_no_origin_pass_gracefully(self):
+        self.consumer_record.origin_exchange_record_id = False
+        logger_name = "odoo.addons.edi_state_oca.models.edi_state_consumer_mixin"
+        with self.assertLogs(logger_name, level="WARN") as logs:
+            self.consumer_record._edi_set_state(self.wf1_ok.state_ids[0])
+            err = (
+                f"No exchange type given for "
+                f"{self.consumer_record._name}#{self.consumer_record.id}"
+            )
+            self.assertIn(err, logs.output[0])
+
     def test_mixin_edi_find_state(self):
         with self.assertRaises(AssertionError):
             self.assertEqual(self.consumer_model.edi_find_state())


### PR DESCRIPTION
Due to outdated data or due to mis-configuration you might have consumer records w/o an origin. When this happens log a warning instead of breaking.