### PR TITLE
[16.0] edi: fix consumer get_view w/ nested forms

### DIFF
--- a/edi_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_oca/models/edi_exchange_consumer_mixin.py
@@ -116,7 +116,9 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         res = super().get_view(view_id, view_type, **options)
         if view_type == "form":
             doc = etree.XML(res["arch"])
-            for node in doc.xpath("//sheet"):
+            # Select main `sheet` only as they can be nested into fields custom forms.
+            # I'm looking at you `account.view_move_line_form` on v16 :S
+            for node in doc.xpath("//sheet[not(ancestor::field)]"):
                 # TODO: add a default group
                 group = False
                 if hasattr(self, "_edi_generate_group"):


### PR DESCRIPTION
Select main  only as they can be nested into field custom forms. I'm looking at you  on v16 :S

Eg: https://github.com/odoo/odoo/blob/114e31521beb1d00f85f8a19959006dfe62708a0/addons/account/views/account_move_views.xml#L991

