### PR TITLE
[16.0][POC] edi_oca: relate multiple records with a single exchange record

### DIFF
--- a/edi_oca/models/__init__.py
+++ b/edi_oca/models/__init__.py
@@ -1,6 +1,7 @@
 from . import edi_backend
 from . import edi_backend_type
 from . import edi_exchange_record
+from . import edi_exchange_related_record
 from . import edi_exchange_consumer_mixin
 from . import edi_exchange_type
 from . import edi_exchange_type_rule

--- a/edi_oca/models/edi_exchange_related_record.py
+++ b/edi_oca/models/edi_exchange_related_record.py
@@ -1,0 +1,63 @@
+# Copyright 2023 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class EDIExchangeRelatedRecord(models.Model):
+    """
+    Model linking an Odoo record with an exchange record.
+    """
+
+    _name = "edi.exchange.related.record"
+    _description = "EDI exchange Related Record"
+    _order = "id"
+
+    exchange_record_id = fields.Many2one(
+        comodel_name="edi.exchange.record",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    model = fields.Char(index=True, required=True, readonly=True)
+    res_id = fields.Many2oneReference(
+        string="Record",
+        index=True,
+        required=True,
+        readonly=True,
+        model_field="model",
+        copy=False,
+    )
+
+    _sql_constraints = [
+        (
+            "related_record_unique",
+            "unique(exchange_record_id, model, res_id)",
+            "A record can only be related once to a specific exchange record.",
+        )
+    ]
+
+    @property
+    def record(self):
+        return self.env[self.model].browse(self.res_id).exists()
+
+    def _notify_related_record(self, message, level="info"):
+        """Post notification on the original record."""
+        if not self.record or not hasattr(self.record, "message_post_with_view"):
+            return
+        self.record.message_post_with_view(
+            "edi_oca.message_edi_exchange_link",
+            values={
+                "backend": self.exchange_record_id.backend_id,
+                "exchange_record": self.exchange_record_id,
+                "message": message,
+                "level": level,
+            },
+            subtype_id=self.env.ref("mail.mt_note").id,
+        )
+
+    def action_open_related_record(self):
+        self.ensure_one()
+        if not self.record:
+            return {}
+        return self.record.get_formview_action()

--- a/edi_oca/security/ir_model_access.xml
+++ b/edi_oca/security/ir_model_access.xml
@@ -45,6 +45,15 @@
         <field name="perm_write" eval="1" />
         <field name="perm_unlink" eval="1" />
     </record>
+    <record model="ir.model.access" id="access_edi_exchange_related_record_manager">
+        <field name="name">access_edi_exchange_related_record manager</field>
+        <field name="model_id" ref="model_edi_exchange_related_record" />
+        <field name="group_id" ref="base_edi.group_edi_manager" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
     <record model="ir.model.access" id="access_edi_backend_type_user">
         <field name="name">access_edi_backend_type user</field>
         <field name="model_id" ref="model_edi_backend_type" />
@@ -84,6 +93,15 @@
     <record model="ir.model.access" id="access_edi_exchange_record_user">
         <field name="name">access_edi_exchange_record user</field>
         <field name="model_id" ref="model_edi_exchange_record" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+    <record model="ir.model.access" id="access_edi_exchange_related_record_user">
+        <field name="name">access_edi_exchange_related_record user</field>
+        <field name="model_id" ref="model_edi_exchange_related_record" />
         <field name="group_id" ref="base.group_user" />
         <field name="perm_read" eval="1" />
         <field name="perm_create" eval="1" />

--- a/edi_oca/views/edi_exchange_record_views.xml
+++ b/edi_oca/views/edi_exchange_record_views.xml
@@ -168,6 +168,25 @@
                               </tree>
                             </field>
                         </page>
+                        <page
+                            name="related_records"
+                            string="Related Records"
+                            attrs="{'invisible': [('related_record_ids', '=', False)]}"
+                        >
+                            <field name="related_record_ids" nolabel="1" colspan="4">
+                              <tree create="false">
+                                <field name="model" />
+                                <field name="res_id" />
+                                <button
+                                        name="action_open_related_record"
+                                        type="object"
+                                        icon="fa-arrow-right"
+                                        string="Open Record"
+                                        attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', False)]}"
+                                    />
+                              </tree>
+                            </field>
+                        </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
In our projects we have faced different scenarios where we have needed to link more than one Odoo record to an exchange record. For example, in a warehouse integration, you could be exchanging a Product Masterdata file including multiple products, and you want them all to be linked to the exchange record.

Currently the EDI framework only allows to link one Odoo record to an exchange record. Using the current code, a solution could be to use the ability to link exchange records in a parent/child relation. However, in the use case presented you will only sent one file, so it is a bit weird to have child exchange records that will simply do nothing.

My goal is to try to find a solution that fits the current code and allows covering these type of use cases. As a generic approach, I am proposing this POC where we could simply add a model to relate multiple records (being from different models) with a single exchange record. Obviously, if this is agreed as a good solution, we would then work in this PR to implement it properly.

Looking forward to get your opinions!

CC @etobella @simahawk @JaumeBforgeFlow 

- [x] Add new model to relate odoo records with a exchange record
- [x] Allow navigating to the related odoo record from the exchange record
- [ ] Always use related records (main record is computed as the first record of the related records)