### PR TITLE
[16.0][IMP] edi_oca: introduce a deduplication mechanism at the sending step

### DIFF
--- a/edi_oca/data/cron.xml
+++ b/edi_oca/data/cron.xml
@@ -33,4 +33,20 @@
         <field name="state">code</field>
         <field name="code">model.search([])._cron_check_input_exchange_sync()</field>
     </record>
+    <record
+        id="cron_edi_backend_delete_obsolete_records"
+        model="ir.cron"
+        forcecreate="True"
+    >
+    <field name="name">EDI exchange delete obsolete records</field>
+    <field name="active" eval="True" />
+    <field name="user_id" ref="base.user_root" />
+    <field name="interval_number">1</field>
+    <field name="interval_type">days</field>
+    <field name="numbercall">-1</field>
+    <field name="doall" eval="False" />
+    <field name="model_id" ref="edi_oca.model_edi_backend" />
+    <field name="state">code</field>
+    <field name="code">model.search([])._cron_delete_obsolete_records()</field>
+</record>
 </odoo>

--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -706,10 +706,8 @@ class EDIBackend(models.Model):
         """Domain for obsolete records need to delete."""
         domain = [
             ("backend_id", "=", self.id),
-            ("type_id.direction", "=", "output"),
             ("type_id.delete_obsolete_records", "=", True),
             ("edi_exchange_state", "=", "obsolete"),
-            ("exchange_file", "!=", False),
         ]
         if record_ids:
             domain.append(("id", "in", record_ids))

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -70,6 +70,7 @@ class EDIExchangeRecord(models.Model):
         selection=[
             # Common states
             ("new", "New"),
+            ("obsolete", "Obsolete"),
             ("validate_error", "Error on validation"),
             # output exchange states
             ("output_pending", "Waiting to be sent"),
@@ -113,6 +114,10 @@ class EDIExchangeRecord(models.Model):
         compute="_compute_retryable",
         help="The record state can be rolled back manually in case of failure.",
     )
+    is_obsolete = fields.Boolean(
+        default=False,
+        compute="_compute_is_obsolete",
+    )
     company_id = fields.Many2one("res.company", string="Company")
 
     _sql_constraints = [
@@ -155,7 +160,7 @@ class EDIExchangeRecord(models.Model):
     @api.constrains("edi_exchange_state")
     def _constrain_edi_exchange_state(self):
         for rec in self:
-            if rec.edi_exchange_state in ("new", "validate_error"):
+            if rec.edi_exchange_state in ("new", "obsolete", "validate_error"):
                 continue
             if not rec.edi_exchange_state.startswith(rec.direction):
                 raise exceptions.ValidationError(
@@ -603,3 +608,26 @@ class EDIExchangeRecord(models.Model):
 
     def _job_retry_params(self):
         return {}
+
+    def _compute_is_obsolete(self):
+        for rec in self:
+            rec.is_obsolete = (
+                rec.type_id.deduplicate_on_send and rec.has_fresher_duplicates()
+            )
+
+    def get_fresher_duplicates(self, count=None):
+        self.ensure_one()
+        fresher_duplicates = self.search(
+            [
+                ("id", ">", self.id),
+                ("res_id", "=", self.res_id),
+                ("model", "=", self.model),
+                ("type_id", "=", self.type_id.id),
+                ("exchange_file", "!=", False),
+            ],
+            count=count,
+        )
+        return fresher_duplicates
+
+    def has_fresher_duplicates(self):
+        return bool(self.get_fresher_duplicates(count=True))

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -118,6 +118,10 @@ class EDIExchangeRecord(models.Model):
         default=False,
         compute="_compute_is_obsolete",
     )
+    block_obsolescence = fields.Boolean(
+        default=False,
+        help="Flag record that can never be marked as obsolete",
+    )
     company_id = fields.Many2one("res.company", string="Company")
 
     _sql_constraints = [
@@ -612,7 +616,9 @@ class EDIExchangeRecord(models.Model):
     def _compute_is_obsolete(self):
         for rec in self:
             rec.is_obsolete = (
-                rec.type_id.deduplicate_on_send and rec.has_fresher_duplicates()
+                rec.type_id.deduplicate_on_send
+                and rec.has_fresher_duplicates()
+                and not rec.block_obsolescence
             )
 
     def get_fresher_duplicates(self, count=None):

--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -181,6 +181,17 @@ class EDIExchangeType(models.Model):
         ],
         help="Handling of decoding errors on process (default is always 'Raise Error').",
     )
+    deduplicate_on_send = fields.Boolean(
+        string="Deduplicate on Send",
+        default=False,
+        help="Before sending an exchange record, check if a fresher one does not "
+        "exist for same record; if so, mark oldest one as obsolete.",
+    )
+    delete_obsolete_records = fields.Boolean(
+        string="Delete obsolete records",
+        default=True,
+        help="Delete records marked as obsolete.",
+    )
 
     _sql_constraints = [
         (

--- a/edi_oca/tests/__init__.py
+++ b/edi_oca/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_edi_backend_cron
 from . import test_security
 from . import test_quick_exec
 from . import test_exchange_type_encoding
+from . import test_edi_deduplicate

--- a/edi_oca/tests/test_edi_backend_cron.py
+++ b/edi_oca/tests/test_edi_backend_cron.py
@@ -92,3 +92,32 @@ class EDIBackendTestCronCase(EDIBackendCommonComponentRegistryTestCase):
         self.assertTrue(FakeOutputGenerator.check_not_called_for(self.record1))
         self.assertTrue(FakeOutputSender.check_not_called_for(self.record1))
         self.assertTrue(FakeOutputChecker.check_called_for(self.record1))
+
+    @mute_logger(*LOGGERS)
+    def test_exchange_delete_obsolete_records(self):
+        self.exchange_type_out.write(
+            {
+                "exchange_file_auto_generate": True,
+                "deduplicate_on_send": True,
+                "delete_obsolete_records": True,
+            }
+        )
+        record1_1 = self.backend.create_record(
+            "test_csv_output", {"model": self.partner._name, "res_id": self.partner.id}
+        )
+        record1_2 = self.backend.create_record(
+            "test_csv_output", {"model": self.partner._name, "res_id": self.partner.id}
+        )
+        record1_3 = self.backend.create_record(
+            "test_csv_output", {"model": self.partner._name, "res_id": self.partner.id}
+        )
+        # all the older records should have been obsolete by record1_3
+        records = self.record1 + record1_1 + record1_2
+        self.backend._check_output_exchange_sync()
+        for record in records:
+            self.assertEqual(record.edi_exchange_state, "obsolete")
+        self.assertEqual(record1_3.edi_exchange_state, "output_sent")
+        self.backend._delete_obsolete_records()
+        for record in records:
+            self.assertFalse(record.exists())
+        self.assertTrue(record1_3.exists())

--- a/edi_oca/tests/test_edi_deduplicate.py
+++ b/edi_oca/tests/test_edi_deduplicate.py
@@ -1,0 +1,87 @@
+# Copyright 2024 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from .common import EDIBackendCommonComponentRegistryTestCase
+from .fake_components import (
+    FakeInputProcess,
+    FakeOutputChecker,
+    FakeOutputGenerator,
+    FakeOutputSender,
+)
+
+LOGGERS = ("odoo.addons.edi_oca.models.edi_backend", "odoo.addons.queue_job.delay")
+
+
+class EDIDeduplicateTestCase(EDIBackendCommonComponentRegistryTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._build_components(
+            cls,
+            FakeOutputGenerator,
+            FakeOutputSender,
+            FakeOutputChecker,
+            FakeInputProcess,
+        )
+        cls.partner = cls.env.ref("base.res_partner_10")
+        cls.exchange_type_out.exchange_file_auto_generate = True
+        cls.record1 = cls.backend.create_record(
+            "test_csv_output",
+            {
+                "model": cls.partner._name,
+                "res_id": cls.partner.id,
+            },
+        )
+        cls.record2 = cls.backend.create_record(
+            "test_csv_output",
+            {
+                "model": cls.partner._name,
+                "res_id": cls.partner.id,
+            },
+        )
+        cls.record3 = cls.backend.create_record(
+            "test_csv_output",
+            {
+                "model": cls.partner._name,
+                "res_id": cls.partner.id,
+            },
+        )
+        cls.record4 = cls.backend.create_record(
+            "test_csv_output",
+            {
+                "model": cls.partner._name,
+                "res_id": cls.partner.id,
+            },
+        )
+        cls.records = cls.record1 + cls.record1 + cls.record3 + cls.record4
+
+    def setUp(self):
+        super().setUp()
+        FakeOutputGenerator.reset_faked()
+        FakeOutputSender.reset_faked()
+        FakeOutputChecker.reset_faked()
+        FakeInputProcess.reset_faked()
+
+    def test_no_deduplicate_on_send(self):
+        self.exchange_type_out.write(
+            {
+                "deduplicate_on_send": False,
+            }
+        )
+        self.backend._check_output_exchange_sync()
+        # All the records should be "output_sent"
+        for record in self.records:
+            self.assertEqual(record.edi_exchange_state, "output_sent")
+
+    def test_deduplicate_on_send(self):
+        self.exchange_type_out.write(
+            {
+                "deduplicate_on_send": True,
+            }
+        )
+        self.backend._check_output_exchange_sync()
+        # Because we just sent the last record, so the others should be "obsolete"
+        self.records = self.records - self.record4
+        for record in self.records:
+            self.assertEqual(record.edi_exchange_state, "obsolete")
+        self.assertEqual(self.record4.edi_exchange_state, "output_sent")

--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -58,6 +58,11 @@
                                 name="encoding_in_error_handler"
                                 attrs="{'invisible': [('direction', '=', 'output')]}"
                             />
+                            <field name="deduplicate_on_send" />
+                            <field
+                                name="delete_obsolete_records"
+                                attrs="{'invisible': [('deduplicate_on_send', '=', False)]}"
+                            />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Rebased on:
- #63 

Example problematic scenario:
- User creates a new customer
- User goes through n rounds of (Edits, Saves)
- This generates n edi.exchange.record
- Given that we always send a full representation of the customer to WAMAS (and not incremental changes), we only need the last exchange record to be sent
- Sending more than the last echange record can create trouble:
 - if for some reason, WAMAS does not process the records in their filename order, it could save an outdated representation of the customer
 - too many records to process might clog queues and/or create delays/high load
 
Solution:
- Introduce a deduplication mechanism in edi_oca at the sending step

Pros:
- If needed for debugging , we can keep track of all the superseded records
- If last change on Customer ends up with a failure of action_exchange_generate, the previous representation will be sent
- The Output Sync cron controls the buffering window: if run every 5 minutes, we'll have at max one WAMAS file every 5 minutes (per customer)

Cons:
- We still generate a lot of queue jobs (generate, send),