### PR TITLE
[16.0][FIX] edi_storage_oca: FS find_files returns relative paths instead of full paths

### DIFF
--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -161,9 +161,10 @@ class EDIBackend(models.Model):
         if exchange_type.exchange_file_ext:
             bits.append(r"\." + exchange_type.exchange_file_ext)
         pattern = "".join(bits)
-        full_paths = utils.find_files(self.storage_id, pattern, full_input_dir_pending)
-        pending_path_len = len(full_input_dir_pending)
-        return [p[pending_path_len:].strip("/") for p in full_paths]
+        relative_paths = utils.find_files(
+            self.storage_id, pattern, full_input_dir_pending
+        )
+        return [p.strip("/") for p in relative_paths]
 
     def _storage_new_exchange_record_vals(self, file_name):
         return {"exchange_filename": file_name, "edi_exchange_state": "input_pending"}


### PR DESCRIPTION
Ex: see SFTP implementation of FS (https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/implementations/sftp.html#SFTPFileSystem)

In the method '_decode_stat' which is used to generate the info returned by 'ls', the result is build using the relative path passed to the method 'ls': `out["name"] = "/".join([parent_path.rstrip("/"), stat.filename])`