### PR TITLE
[16.0][FIX] edi_stock_oca: fixing missing string field information from the stock.picking model

### DIFF
--- a/edi_stock_oca/views/stock_picking.xml
+++ b/edi_stock_oca/views/stock_picking.xml
@@ -8,6 +8,10 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
+            <xpath expr="//header" position="before">
+               <field name="edi_config" invisible="1" />
+               <field name="edi_has_form_config" invisible="1" />
+            </xpath>
             <page name="extra" position="after">
                 <page name="edi" string="EDI">
                     <group name="edi_stock_group" string="Electronic Data Interchange">


### PR DESCRIPTION
![image](https://github.com/OCA/edi-framework/assets/127363167/a937a90a-e866-4e7a-b63a-1e45091fb5dc)

The error starts from: [here](https://github.com/OCA/edi-framework/blob/28419ba5c34cc9b538ba99ab35c36d85130491e0/edi_oca/models/edi_exchange_consumer_mixin.py#L137)

Throw error: [here](https://github.com/odoo/odoo/blob/e4604cc10dfc7e7e87ac73dfbd41b1ab92b0c100/addons/web/static/src/legacy/legacy_load_views.js#L69)

Solutions:
- if add more `string` attrb in the fields in [the template](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/templates/exchange_mixin_buttons.xml), it will throw [new error](https://github.com/odoo/odoo/blob/e4604cc10dfc7e7e87ac73dfbd41b1ab92b0c100/addons/web/static/src/legacy/legacy_load_views.js#L83C50-L83C59) (because viewFieldsInfo is still `undefined`)
- so we make viewFieldsInfo is not undefined ( it hasn't been undefined when the `fieldName` appears in the form `stock.picking`) --> So we make `edi_config` and `edi_has_form_config` appear in stock.picking form view)