### PR TITLE
[16.0][IMP] edi_storage_oca: do not ignore OSError when getting remote file

### DIFF
--- a/edi_storage_oca/components/base.py
+++ b/edi_storage_oca/components/base.py
@@ -77,11 +77,3 @@ class EDIStorageComponentMixin(AbstractComponent):
                 state,
             )
             return None
-        except OSError:
-            _logger.info(
-                "Ignored OSError when trying to get file %s into path %s for state %s",
-                filename,
-                path,
-                state,
-            )
-            return None


### PR DESCRIPTION
When the fs_storage connection fails, it can raise OSError here: https://github.com/OCA/storage/blob/4d82d00aaec818c10dfcfe509d9640d48ebffbf2/fs_storage/models/fs_storage.py#L294.

