### PR TITLE
[16.0][IMP] edi_storage_oca: new opt-in technical field to avoid moving files after processing

### DIFF
--- a/edi_storage_oca/__manifest__.py
+++ b/edi_storage_oca/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": """
     Base module to allow exchanging files via storage backend (eg: SFTP).
     """,
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "development_status": "Beta",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/edi-framework",

--- a/edi_storage_oca/components/listener.py
+++ b/edi_storage_oca/components/listener.py
@@ -40,7 +40,7 @@ class EdiStorageListener(Component):
         )
 
     def on_edi_exchange_done(self, record):
-        storage = record.backend_id.storage_id
+        storage = record.storage_id
         res = False
         if record.direction == "input" and storage:
             file = record.exchange_filename
@@ -64,7 +64,7 @@ class EdiStorageListener(Component):
         return res
 
     def on_edi_exchange_error(self, record):
-        storage = record.backend_id.storage_id
+        storage = record.storage_id
         res = False
         if record.direction == "input" and storage:
             file = record.exchange_filename

--- a/edi_storage_oca/migrations/16.0.1.0.2/post-migrate.py
+++ b/edi_storage_oca/migrations/16.0.1.0.2/post-migrate.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    cr.execute(
+        """
+        UPDATE edi_exchange_record AS e
+        SET storage_id = b.storage_id
+        FROM edi_backend AS b
+        WHERE e.backend_id = b.id;
+        """
+    )

--- a/edi_storage_oca/models/__init__.py
+++ b/edi_storage_oca/models/__init__.py
@@ -1,2 +1,3 @@
 from . import edi_backend
 from . import edi_exchange_type
+from . import edi_exchange_record

--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -139,7 +139,8 @@ class EDIBackend(models.Model):
         if existing:
             return
         record = self.create_record(
-            exchange_type.code, self._storage_new_exchange_record_vals(file_name)
+            exchange_type.code,
+            self._storage_new_exchange_record_vals(file_name),
         )
         _logger.debug("%s: new exchange record generated.", self.name)
         return record.identifier
@@ -166,4 +167,8 @@ class EDIBackend(models.Model):
         return [p[pending_path_len:].strip("/") for p in full_paths]
 
     def _storage_new_exchange_record_vals(self, file_name):
-        return {"exchange_filename": file_name, "edi_exchange_state": "input_pending"}
+        return {
+            "exchange_filename": file_name,
+            "edi_exchange_state": "input_pending",
+            "storage_id": self.storage_id.id,
+        }

--- a/edi_storage_oca/models/edi_exchange_record.py
+++ b/edi_storage_oca/models/edi_exchange_record.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class EDIExchangeRecord(models.Model):
+    _inherit = "edi.exchange.record"
+
+    storage_id = fields.Many2one(
+        comodel_name="fs.storage",
+        readonly=True,
+        string="FS Storage",
+        help="Record created from a file found in this FS storage",
+    )

--- a/edi_storage_oca/tests/test_edi_storage_listener.py
+++ b/edi_storage_oca/tests/test_edi_storage_listener.py
@@ -48,7 +48,12 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
 
     def test_01_process_record_success(self):
         with self._mock_listener_move_file():
-            self.record.write({"edi_exchange_state": "input_received"})
+            self.record.write(
+                {
+                    "edi_exchange_state": "input_received",
+                    "storage_id": self.backend.storage_id.id,
+                }
+            )
             self.record.action_exchange_process()
             storage, from_dir_str, to_dir_str, filename = self.fake_move_args
             self.assertEqual(storage, self.backend.storage_id)
@@ -58,7 +63,12 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
 
     def test_02_process_record_with_error(self):
         with self._mock_listener_move_file():
-            self.record.write({"edi_exchange_state": "input_received"})
+            self.record.write(
+                {
+                    "edi_exchange_state": "input_received",
+                    "storage_id": self.backend.storage_id.id,
+                }
+            )
             self.record._set_file_content("TEST %d" % self.record.id)
             self.record.with_context(
                 test_break_process="OOPS! Something went wrong :("


### PR DESCRIPTION
In some contexts, we might have an EDI Exchange Type with both:

- a storage (e.g. files pushed to a SFTP)

- AND an endpoint

If a record is created through the endpoint, we want to disable the logic that moves files after processing (implemented as a listener:
https://github.com/oca/edi-framework/blob/16.0/edi_storage_oca/components/listener.py#L13)