### PR TITLE
[IMP] edi_oca: add a backend_type_code field on the backend

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -50,6 +50,7 @@ class EDIBackend(models.Model):
         required=True,
         ondelete="restrict",
     )
+    backend_type_code = fields.Char(related="backend_type_id.code")
     output_sent_processed_auto = fields.Boolean(
         help="""
     Automatically set the record as processed after sending.

--- a/edi_oca/views/edi_backend_views.xml
+++ b/edi_oca/views/edi_backend_views.xml
@@ -50,6 +50,8 @@
                         </h2>
                     </div>
                     <group>
+                        <!-- can be used to hide elements based on the backend type, e.g. notebook pages -->
+                        <field name="backend_type_code" invisible="1" />
                         <field name="output_sent_processed_auto" />
                         <field name="active" invisible="1" />
                         <field name="company_id" groups="base.group_multi_company" />


### PR DESCRIPTION
this field can be used in backend views to show/hide configuration elements depending on the backend type