### PR TITLE
[16.0][FIX] edi_partner_oca: fix partner form

### DIFF
--- a/edi_partner_oca/views/partner_views.xml
+++ b/edi_partner_oca/views/partner_views.xml
@@ -6,6 +6,8 @@
         <field name="inherit_id" ref="edi_oca.view_partner_form" />
         <field name="arch" type="xml">
             <group name="edi_main" position="inside">
+                <field name="edi_config" invisible="1" />
+                <field name="edi_has_form_config" invisible="1" />
                 <field name="edi_disable_auto" />
             </group>
             <div name="button_box" position="inside">


### PR DESCRIPTION

![image](https://github.com/OCA/edi-framework/assets/67733397/432a4ea8-b9a9-437d-88f7-f106f7ae5daa)

Same issue we had here: https://github.com/OCA/edi-framework/pull/68
