### PR TITLE
[16.0] edi_storage: fix list_files

### DIFF
--- a/edi_storage_oca/components/listener.py
+++ b/edi_storage_oca/components/listener.py
@@ -20,7 +20,7 @@ class EdiStorageListener(Component):
         # - storage.list_files now includes path in fs_storage, breaking change
         # - we remove path
         files = utils.list_files(storage, from_dir.as_posix())
-        files = [os.path.basename(f) for f in files]
+        files = [os.path.basename(f["name"]) for f in files]
         if filename not in files:
             return False
         self._add_post_commit_hook(

--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -152,9 +152,9 @@ class EDIBackend(models.Model):
         if not exchange_type.exchange_filename_pattern:
             # If there is not pattern, return everything
             filenames = [
-                x
+                x["name"]
                 for x in utils.list_files(self.storage_id, full_input_dir_pending)
-                if x.strip("/")
+                if x["name"].strip("/")
             ]
             return filenames
 

--- a/edi_storage_oca/tests/common.py
+++ b/edi_storage_oca/tests/common.py
@@ -99,7 +99,7 @@ class TestEDIStorageBase(EDIBackendCommonComponentTestCase):
         path_length = len(path)
         for p in mocked_paths.keys():
             if path in p and path != p:
-                files.append(p[path_length:])
+                files.append({"name": p[path_length:]})
         return files
 
     def _mock_fs_storage_get(self, mocked_paths):

--- a/edi_storage_oca/utils.py
+++ b/edi_storage_oca/utils.py
@@ -26,7 +26,8 @@ def find_files(storage, pattern, relative_path="", **kw) -> list[str]:
     if not fs.exists(relative_path):
         return []
     regex = re.compile(pattern)
-    for file_path in fs.ls(relative_path):
+    for item in fs.ls(relative_path):
+        file_path = item["name"]
         # fs.ls returns a relative path
         if regex.match(os.path.basename(file_path)):
             result.append(file_path)

--- a/edi_storage_oca/utils.py
+++ b/edi_storage_oca/utils.py
@@ -48,7 +48,7 @@ def list_files(storage, relative_path="", pattern=False):
     if pattern:
         relative_path = fs.sep.join([relative_path, pattern])
         return fs.glob(relative_path)
-    return fs.ls(relative_path, detail=False)
+    return fs.ls(relative_path)
 
 
 def move_files(storage, files, destination_path, **kw):

--- a/edi_storage_oca/utils.py
+++ b/edi_storage_oca/utils.py
@@ -26,7 +26,7 @@ def find_files(storage, pattern, relative_path="", **kw) -> list[str]:
     if not fs.exists(relative_path):
         return []
     regex = re.compile(pattern)
-    for file_path in fs.ls(relative_path, detail=False):
+    for file_path in fs.ls(relative_path):
         # fs.ls returns a relative path
         if regex.match(os.path.basename(file_path)):
             result.append(file_path)


### PR DESCRIPTION
TODO: explanation... don't know yet why this is happening for certain SFTP server only.

With `detail=False` it breaks like this:
```
>>> fs.ls(fpath.as_posix(), detail=False)
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.10/site-packages/fsspec/implementations/dirfs.py", line 255, in ls
    return self._relpath(ret)
  File "/usr/local/lib/python3.10/site-packages/fsspec/implementations/dirfs.py", line 70, in _relpath
    return [self._relpath(_path) for _path in path]
  File "/usr/local/lib/python3.10/site-packages/fsspec/implementations/dirfs.py", line 70, in <listcomp>
    return [self._relpath(_path) for _path in path]
  File "/usr/local/lib/python3.10/site-packages/fsspec/implementations/dirfs.py", line 68, in _relpath
    assert path.startswith(prefix)
AssertionError
```