### PR TITLE
[IMP] edi_oca: Improve archive/unarchive exchange type rules

### DIFF
--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -30,7 +30,7 @@ class EDIExchangeType(models.Model):
     _name = "edi.exchange.type"
     _description = "EDI Exchange Type"
 
-    active = fields.Boolean(default=True, inverse="_inverse_active")
+    active = fields.Boolean(default=True)
     backend_id = fields.Many2one(
         string="Backend",
         comodel_name="edi.backend",
@@ -189,12 +189,6 @@ class EDIExchangeType(models.Model):
             "The code must be unique per backend",
         )
     ]
-
-    def _inverse_active(self):
-        for rec in self:
-            # Disable rules if type gets disabled
-            if not rec.active:
-                rec.rule_ids.active = False
 
     @api.depends("advanced_settings_edit")
     def _compute_advanced_settings(self):

--- a/edi_oca/models/edi_exchange_type_rule.py
+++ b/edi_oca/models/edi_exchange_type_rule.py
@@ -2,7 +2,7 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 KIND_HELP = """
 * Form button: show a button on the related model form
@@ -20,7 +20,9 @@ class EDIExchangeTypeRule(models.Model):
     _name = "edi.exchange.type.rule"
     _description = "EDI Exchange type rule"
 
-    active = fields.Boolean(default=True)
+    active = fields.Boolean(
+        default=True, compute="_compute_active", store=True, readonly=False
+    )
     name = fields.Char(required=True)
     type_id = fields.Many2one(
         comodel_name="edi.exchange.type",
@@ -60,3 +62,8 @@ class EDIExchangeTypeRule(models.Model):
         translate=True,
         help="Help message visible as tooltip on button h-over",
     )
+
+    @api.depends("type_id.active")
+    def _compute_active(self):
+        for rec in self:
+            rec.active = rec.type_id.active

--- a/edi_oca/tests/test_exchange_type.py
+++ b/edi_oca/tests/test_exchange_type.py
@@ -154,7 +154,9 @@ class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
             }
         )
         exc_type.active = False
-        rule1.invalidate_recordset()
-        rule2.invalidate_recordset()
         self.assertFalse(rule1.active)
         self.assertFalse(rule2.active)
+        # Enable the type
+        exc_type.active = True
+        self.assertTrue(rule1.active)
+        self.assertTrue(rule2.active)


### PR DESCRIPTION
Change of behavior:
  - When an exchange type is archived, its exchange type rules are also archived (same as before)
  - When an exchange type is re-activated, its exchange type rules are also re-activated (new)