### PR TITLE
[FIX] edi_product_oca: fixing missing string field information from the product.template

### DIFF
--- a/edi_product_oca/views/product_views.xml
+++ b/edi_product_oca/views/product_views.xml
@@ -5,6 +5,10 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
+            <xpath expr="//header" position="before">
+                <field name="edi_config" invisible="1" />
+                <field name="edi_has_form_config" invisible="1" />
+            </xpath>
 
             <page name="inventory" position="after">
                 <page name="edi" string="EDI">


### PR DESCRIPTION
![image](https://github.com/OCA/edi-framework/assets/67733397/47fb5d36-a4ee-4b5a-80d4-9a0d69f483c5)

The error starts from: [here](https://github.com/OCA/edi-framework/blob/28419ba5c34cc9b538ba99ab35c36d85130491e0/edi_oca/models/edi_exchange_consumer_mixin.py#L137)

Throw error: [here](https://github.com/odoo/odoo/blob/e4604cc10dfc7e7e87ac73dfbd41b1ab92b0c100/addons/web/static/src/legacy/legacy_load_views.js#L69)