### PR TITLE
[16.0][IMP] edi_oca: allow to receive empty files

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -272,6 +272,12 @@ class EDIBackend(models.Model):
 
     # TODO: add tests
     def _validate_data(self, exchange_record, value=None, **kw):
+        if exchange_record.direction == "input" and not exchange_record.exchange_file:
+            if not exchange_record.type_id.allow_empty_files_on_receive:
+                raise ValueError(
+                    _("Empty files are not allowed for this exchange type")
+                )
+
         component = self._get_component(exchange_record, "validate")
         if component:
             return component.validate(value)
@@ -456,7 +462,10 @@ class EDIBackend(models.Model):
             raise exceptions.UserError(
                 _("Record ID=%d is not meant to be processed") % exchange_record.id
             )
-        if not exchange_record.exchange_file:
+        if (
+            not exchange_record.exchange_file
+            and not exchange_record.type_id.allow_empty_files_on_receive
+        ):
             raise exceptions.UserError(
                 _("Record ID=%d has no file to process!") % exchange_record.id
             )
@@ -527,7 +536,8 @@ class EDIBackend(models.Model):
         content = None
         try:
             content = self._exchange_receive(exchange_record)
-            if content:
+            # Ignore result of FileNotFoundError/OSError
+            if content is not None:
                 exchange_record._set_file_content(content)
                 self._validate_data(exchange_record)
         except EDIValidationError:

--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -181,6 +181,7 @@ class EDIExchangeType(models.Model):
         ],
         help="Handling of decoding errors on process (default is always 'Raise Error').",
     )
+    allow_empty_files_on_receive = fields.Boolean(string="Allow Empty Files")
 
     _sql_constraints = [
         (

--- a/edi_oca/tests/test_backend_input.py
+++ b/edi_oca/tests/test_backend_input.py
@@ -43,3 +43,26 @@ class EDIBackendTestInputCase(EDIBackendCommonComponentRegistryTestCase):
         self.backend.with_context(fake_output="yeah!").exchange_receive(self.record)
         self.assertEqual(self.record._get_file_content(), "yeah!")
         self.assertRecordValues(self.record, [{"edi_exchange_state": "input_received"}])
+
+    def test_receive_no_allow_empty_file_record(self):
+        self.record.edi_exchange_state = "input_pending"
+        self.backend.with_context(
+            fake_output="", _edi_receive_break_on_error=False
+        ).exchange_receive(self.record)
+        # Check the record
+        msg = "Empty files are not allowed for this exchange type"
+        self.assertIn(msg, self.record.exchange_error)
+        self.assertEqual(self.record._get_file_content(), "")
+        self.assertRecordValues(
+            self.record, [{"edi_exchange_state": "input_receive_error"}]
+        )
+
+    def test_receive_allow_empty_file_record(self):
+        self.record.edi_exchange_state = "input_pending"
+        self.record.type_id.allow_empty_files_on_receive = True
+        self.backend.with_context(
+            fake_output="", _edi_receive_break_on_error=False
+        ).exchange_receive(self.record)
+        # Check the record
+        self.assertEqual(self.record._get_file_content(), "")
+        self.assertRecordValues(self.record, [{"edi_exchange_state": "input_received"}])

--- a/edi_oca/tests/test_backend_process.py
+++ b/edi_oca/tests/test_backend_process.py
@@ -67,8 +67,17 @@ class EDIBackendTestProcessCase(EDIBackendCommonComponentRegistryTestCase):
     def test_process_no_file_record(self):
         self.record.write({"edi_exchange_state": "input_received"})
         self.record.exchange_file = False
+        self.exchange_type_in.allow_empty_files_on_receive = False
         with self.assertRaises(UserError):
             self.record.action_exchange_process()
+
+    @mute_logger("odoo.models.unlink")
+    def test_process_allow_no_file_record(self):
+        self.record.write({"edi_exchange_state": "input_received"})
+        self.record.exchange_file = False
+        self.exchange_type_in.allow_empty_files_on_receive = True
+        self.record.action_exchange_process()
+        self.assertEqual(self.record.edi_exchange_state, "input_processed")
 
     def test_process_outbound_record(self):
         vals = {

--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -58,6 +58,10 @@
                                 name="encoding_in_error_handler"
                                 attrs="{'invisible': [('direction', '=', 'output')]}"
                             />
+                            <field
+                                name="allow_empty_files_on_receive"
+                                attrs="{'invisible': [('direction', '=', 'output')]}"
+                            />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Currently when we receive an empty file:
- Receive step doesn't end up in state error_on_receive : that's because we just ignore the content [here](https://github.com/OCA/edi-framework/blob/77184146551ea042190ca7b0a1c290f848dd202f/edi_oca/models/edi_backend.py#L530)
- But the [process step will raise an error](https://github.com/OCA/edi-framework/blob/77184146551ea042190ca7b0a1c290f848dd202f/edi_oca/models/edi_backend.py#L460)
- So this PR goal tries to improve that
- By default, this option is disabled so we still consider that an empty file is an error case