### PR TITLE
[16.0][FIX] edi_storage_oca: do not silently ignore OSError/FileNotFoundError

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -539,7 +539,6 @@ class EDIBackend(models.Model):
         content = None
         try:
             content = self._exchange_receive(exchange_record)
-            # Ignore result of FileNotFoundError/OSError
             if content is not None:
                 exchange_record._set_file_content(content)
                 self._validate_data(exchange_record)

--- a/edi_storage_oca/components/receive.py
+++ b/edi_storage_oca/components/receive.py
@@ -14,4 +14,4 @@ class EDIStorageReceiveComponent(Component):
     _usage = "storage.receive"
 
     def receive(self):
-        return self._get_remote_file("pending", binary=True)
+        return self._get_remote_file("pending", binary=True, raise_if_not_found=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 odoo_test_helper
 responses
 xmlunittest
+odoo-addon-queue_job @ git+https://github.com/OCA/queue.git@refs/pull/674/head#subdirectory=setup/queue_job


### PR DESCRIPTION
Depends on https://github.com/OCA/queue/pull/674

- if an `OSError` is raised, there can be different cases but it's likely a transient issue (e.g. connection error):
  - if we ignore it as currently:
    - Job won't fail
    - the exchange record will be incorrectly marked as "input_received" but with no data, which is not what we want
  - so we don't ignore it anymore:
    - Job will fail;
    - ~~the record state will stay as "input_pending" (as exception won't be catched in [edi.backend:exchange_receive](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L537))~~
    - ~~and as such, another `action_exchange_receive` Job will be created next time scheduled action "EDI exchange check input sync" runs, to try again to receive it, hopefully successfully this time~~
    - a `RetryableJobError` will be raised in order to retry it
    - if it sill can't succeed after `max_retries`, record state will be changed to "input_receive_error"

- if a `FileNotFoundError` is raised, it's not a transient issue, so record should be marked as "input_receive_error":
  - to do so we don't ignore it anymore:
    - it will get catched in [edi.backend:exchange_receive](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L537) as a ["swallable"](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L548) (Final) error
    - record state will be changed to "input_receive_error"