### PR TITLE
[16.0][FIX] edi_oca: do not try to automatically re-process input_processed_error records

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -633,7 +633,7 @@ class EDIBackend(models.Model):
         return domain
 
     def _input_pending_process_records_domain(self, record_ids=None):
-        states = ("input_received", "input_processed_error")
+        states = ("input_received",)
         domain = [
             ("backend_id", "=", self.id),
             ("type_id.direction", "=", "input"),

--- a/edi_oca/tests/test_backend_jobs.py
+++ b/edi_oca/tests/test_backend_jobs.py
@@ -95,3 +95,24 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
         job = self.backend.with_delay().exchange_process(record)
         created = job_counter.search_created()
         self.assertEqual(created[0].name, "Process an incoming document.")
+
+    def test_input_processed_error(self):
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "edi_exchange_state": "input_received",
+        }
+        record = self.backend.create_record("test_csv_input", vals)
+        record._set_file_content("ABC")
+        # Process `input_received` records
+        job_counter = self.job_counter()
+        self.backend._check_input_exchange_sync()
+        created = job_counter.search_created()
+        # Create job
+        self.assertEqual(len(created), 1)
+        record.edi_exchange_state = "input_processed_error"
+        # Don't re-process `input_processed_error` records
+        self.backend._check_input_exchange_sync()
+        new_created = job_counter.search_created() - created
+        # Should not create new job
+        self.assertEqual(len(new_created), 0)


### PR DESCRIPTION
- scheduled action "EDI exchange check input sync" will currently create `action_exchange_process` jobs for any record in state "input_processed_error"
- this does not make any sense, as such records failed to process because of ["swallable"](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L490) exceptions, that should be considered as final