### PR TITLE
[16.0][IMP] edi_oca: Don't run quick_exec if backend is not active

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -265,7 +265,7 @@ class EDIExchangeRecord(models.Model):
     def _quick_exec_enabled(self):
         if self.env.context.get("edi__skip_quick_exec"):
             return False
-        return self.type_id.quick_exec
+        return self.type_id.quick_exec and self.backend_id.active
 
     def _execute_next_action(self):
         # The backend already knows how to handle records


### PR DESCRIPTION
Deactivating the backend temporarily disables certain exchange services. 

Currently, quick execution does not check whether the backend is active. This PR adds an additional check to ensure that quick_exec is only run when the backend is active.

CC @ForgeFlow