### PR TITLE
[16.0][IMP] edi_oca: add smart button in record form to show all related queue jobs

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -5,6 +5,7 @@
 
 import base64
 import logging
+from ast import literal_eval
 from collections import defaultdict
 
 from odoo import _, api, exceptions, fields, models
@@ -112,6 +113,9 @@ class EDIExchangeRecord(models.Model):
     retryable = fields.Boolean(
         compute="_compute_retryable",
         help="The record state can be rolled back manually in case of failure.",
+    )
+    related_queue_jobs_count = fields.Integer(
+        compute="_compute_related_queue_jobs_count"
     )
     company_id = fields.Many2one("res.company", string="Company")
 
@@ -610,3 +614,32 @@ class EDIExchangeRecord(models.Model):
 
     def _job_retry_params(self):
         return {}
+
+    def _compute_related_queue_jobs_count(self):
+        for rec in self:
+            # TODO: We should refactor the object field on queue_job to use jsonb field
+            # so that we can search directly into it.
+            rec.related_queue_jobs_count = rec.env["queue.job"].search_count(
+                [("func_string", "like", str(rec))]
+            )
+
+    def action_view_related_queue_jobs(self):
+        self.ensure_one()
+        xmlid = "queue_job.action_queue_job"
+        action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
+        # Searching based on task name. Ex: `edi.exchange.record(1,).action_exchange_send()`
+        # TODO: We should refactor the object field on queue_job to use jsonb field
+        # so that we can search directly into it.
+        action["domain"] = [("func_string", "like", str(self))]
+        # Purge default search filters from ctx to avoid hiding records
+        ctx = action.get("context", {})
+        if isinstance(ctx, str):
+            ctx = literal_eval(ctx)
+        # Update the current contexts
+        ctx.update(self.env.context)
+        action["context"] = {
+            k: v for k, v in ctx.items() if not k.startswith("search_default_")
+        }
+        # Drop ID otherwise the context will be loaded from the action's record
+        action.pop("id")
+        return action

--- a/edi_oca/readme/CONFIGURE.rst
+++ b/edi_oca/readme/CONFIGURE.rst
@@ -10,6 +10,15 @@ In order to define a new Exchange Record, we need to configure:
 * Backend
 * Components
 
+Jobs
+~~~~~~~~~~~~~~~~~~~~
+
+* (1) **Internal User**: might be an EDI user without even knowing about it, triggering EDI flows by some of his actions on business records; does not need access to related queue jobs.
+
+* (2) **EDI User**: more conscious EDI user that might sometimes need to debug things a bit further and thus needs access to related queue jobs.
+
+* (3) **EDI Manager**: full configuration access.
+
 Component definition
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edi_oca/readme/CONFIGURE.rst
+++ b/edi_oca/readme/CONFIGURE.rst
@@ -11,7 +11,7 @@ In order to define a new Exchange Record, we need to configure:
 * Components
 
 Jobs
-~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 * (1) **Internal User**: might be an EDI user without even knowing about it, triggering EDI flows by some of his actions on business records; does not need access to related queue jobs.
 

--- a/edi_oca/security/ir_model_access.xml
+++ b/edi_oca/security/ir_model_access.xml
@@ -45,6 +45,18 @@
         <field name="perm_write" eval="1" />
         <field name="perm_unlink" eval="1" />
     </record>
+
+    <!-- Access right to read related jobs on record -->
+    <record model="ir.model.access" id="access_queue_job_user">
+        <field name="name">access_queue_job edi user</field>
+        <field name="model_id" ref="queue_job.model_queue_job" />
+        <field name="group_id" ref="base_edi.group_edi_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
     <record model="ir.model.access" id="access_edi_backend_type_user">
         <field name="name">access_edi_backend_type user</field>
         <field name="model_id" ref="model_edi_backend_type" />

--- a/edi_oca/tests/test_backend_jobs.py
+++ b/edi_oca/tests/test_backend_jobs.py
@@ -17,6 +17,12 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
     def _setup_context(cls):
         return dict(super()._setup_context(), test_queue_job_no_delay=None)
 
+    def _get_related_jobs(self, record):
+        # Use domain in action to find all related jobs
+        record.ensure_one()
+        action = record.action_view_related_queue_jobs()
+        return self.env["queue.job"].search(action["domain"])
+
     def test_output(self):
         job_counter = self.job_counter()
         vals = {
@@ -31,6 +37,8 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
         self.assertEqual(
             created.name, "Generate output content for given exchange record."
         )
+        # Check related jobs
+        self.assertEqual(created, self._get_related_jobs(record))
         with mock.patch.object(
             type(self.backend), "_exchange_generate"
         ) as mocked_generate, mock.patch.object(
@@ -49,6 +57,9 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
             self.assertEqual(res, "Exchange sent")
             self.assertEqual(record.edi_exchange_state, "output_sent")
         self.assertEqual(created[0].name, "Send exchange file.")
+        # Check related jobs
+        record.invalidate_recordset()
+        self.assertEqual(created, self._get_related_jobs(record))
 
     def test_output_fail_retry(self):
         job_counter = self.job_counter()
@@ -77,6 +88,8 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
         created = job_counter.search_created()
         self.assertEqual(len(created), 1)
         self.assertEqual(created.name, "Retrieve an incoming document.")
+        # Check related jobs
+        self.assertEqual(created, self._get_related_jobs(record))
         with mock.patch.object(
             type(self.backend), "_exchange_receive"
         ) as mocked_receive, mock.patch.object(
@@ -116,3 +129,6 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
         new_created = job_counter.search_created() - created
         # Should not create new job
         self.assertEqual(len(new_created), 0)
+        # Check related jobs
+        record.invalidate_recordset()
+        self.assertEqual(created, self._get_related_jobs(record))

--- a/edi_oca/tests/test_security.py
+++ b/edi_oca/tests/test_security.py
@@ -55,7 +55,7 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
                     "name": "Poor Partner (not integrating one)",
                     "email": "poor.partner@ododo.com",
                     "login": "poorpartner",
-                    "groups_id": [(6, 0, [cls.env.ref("base.group_user").id])],
+                    "groups_id": [(6, 0, [cls.env.ref("base_edi.group_edi_user").id])],
                 }
             )
         )

--- a/edi_oca/views/edi_exchange_record_views.xml
+++ b/edi_oca/views/edi_exchange_record_views.xml
@@ -94,6 +94,23 @@
                     />
                 </header>
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-calendar"
+                            name="action_view_related_queue_jobs"
+                            attrs="{'invisible': [('related_queue_jobs_count', '=', 0)]}"
+                            groups="base_edi.group_edi_user"
+                        >
+                            <field
+                                string="Jobs"
+                                name="related_queue_jobs_count"
+                                widget="statinfo"
+                                readonly="1"
+                            />
+                        </button>
+                    </div>
                     <div class="oe_title">
                         <label for="identifier" class="oe_edit_only" />
                         <h1>


### PR DESCRIPTION
This PR adds a smart button in record form to show all related queue jobs

Depend on:
- https://github.com/OCA/edi/pull/1004