### PR TITLE
[16.0][FWD] edi_endpoint: fix form view inheritance

### DIFF
--- a/edi_endpoint_oca/views/edi_endpoint_views.xml
+++ b/edi_endpoint_oca/views/edi_endpoint_views.xml
@@ -5,7 +5,7 @@
 
     <record model="ir.ui.view" id="edi_endpoint_form_view">
         <field name="model">edi.endpoint</field>
-        <field name="inherit_id" ref="endpoint.endpoint_endpoint_form_view" />
+        <field name="inherit_id" ref="endpoint.endpoint_mixin_form_view" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('alert')]" position="before">


### PR DESCRIPTION
The new mixin view won't be affected by weird extensions.

Requires https://github.com/OCA/web-api/pull/57
Solves conflict w/ https://github.com/OCA/web-api-contrib/pull/1

FWD port of https://github.com/OCA/edi/pull/1012