### PR TITLE
[16.0][FIX] edi_oca: consider parent record when checking access rule

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -573,10 +573,15 @@ class EDIExchangeRecord(models.Model):
         for exc_rec in self.sudo():
             if not exc_rec.related_record_exists:
                 continue
-            by_model_rec_ids[exc_rec.model].add(exc_rec.res_id)
-            if exc_rec.model not in by_model_checker:
-                by_model_checker[exc_rec.model] = getattr(
-                    self.env[exc_rec.model], "get_edi_access", default_checker
+            model = exc_rec.model
+            res_id = exc_rec.res_id
+            if not model and exc_rec.parent_id:
+                model = exc_rec.parent_id.model
+                res_id = exc_rec.parent_id.res_id
+            by_model_rec_ids[model].add(res_id)
+            if model not in by_model_checker:
+                by_model_checker[model] = getattr(
+                    self.env[model], "get_edi_access", default_checker
                 )
 
         for model, rec_ids in by_model_rec_ids.items():

--- a/edi_oca/tests/test_security.py
+++ b/edi_oca/tests/test_security.py
@@ -229,3 +229,16 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         msg = rf"not allowed to modify '{model._description}' \({model._name}\)"
         with self.assertRaisesRegex(AccessError, msg):
             exchange_record.with_user(self.user).write({"external_identifier": "1234"})
+
+    @mute_logger("odoo.addons.base.models.ir_model")
+    def test_no_group_no_read_child(self):
+        exchange_record = self.create_record()
+        model = self.consumer_record
+        # Create child record without specific model and res_id
+        # It should follow the access rights of the parent
+        child_exchange_record = self.backend.create_record(
+            "test_csv_output", {"parent_id": exchange_record.id}
+        )
+        msg = rf"not allowed to access '{model._description}' \({model._name}\)"
+        with self.assertRaisesRegex(AccessError, msg):
+            child_exchange_record.with_user(self.user).read()


### PR DESCRIPTION
This fix prevents an error raised when you have child exchanges that do not have a specific model and res_id assigned.

When getting the related record of a child we are already looking at the parent if the exchange record does not have a specific model set (https://github.com/OCA/edi-framework/blob/d484f0dcbb7b1caca1aaae0f9a3c2b3510a714f5/edi_oca/models/edi_exchange_record.py#L210). The same should be done when checking the access.