### PR TITLE
[17.0][IMP] edi_oca: remove logs' warnings causes

### DIFF
--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -67,10 +67,8 @@
                             string="Model rules"
                             groups="edi_oca.group_edi_advanced_settings_manager"
                         >
-                            <field
-                                name="rule_ids"
-                                context="{'default_type_id': active_id}"
-                            >
+                            <field name="id" invisible="1" />
+                            <field name="rule_ids" context="{'default_type_id': id}">
                                 <tree decoration-muted="(not active)">
                                     <field name="active" invisible="1" />
                                     <field name="name" />


### PR DESCRIPTION
Remove usage of ``active_id`` from view

NB: there's another warning due to the fact that both fields `edi.exchange.type.rule.model` and `edi.exchange.type.rule.model_id` have the same string. However, that warning is already handled in https://github.com/OCA/edi-framework/pull/118.