### PR TITLE
[18.0] edi_oca: extract _handle_new_output_exchange_records 

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -278,8 +278,10 @@ class EDIExchangeRecord(models.Model):
         # according to their direction and status.
         # Let it decide.
         if self.type_id.direction == "output":
-            self.backend_id._check_output_exchange_sync(record_ids=self.ids)
+            self.backend_id.exchange_generate_send(self)
         else:
+            # TODO: do not rely on the cron method and create a
+            # specific handle method like it has been done for the output
             self.backend_id._check_input_exchange_sync(record_ids=self.ids)
 
     @api.constrains("backend_id", "type_id")

--- a/edi_oca/tests/test_quick_exec.py
+++ b/edi_oca/tests/test_quick_exec.py
@@ -67,6 +67,25 @@ class EDIQuickExecTestCase(EDIBackendCommonComponentRegistryTestCase):
             self.assertEqual(record0.edi_exchange_state, "new")
 
     @mute_logger(*LOGGERS)
+    def test_quick_exec(self):
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        model = self.env["edi.exchange.record"]
+        with mock.patch.object(type(model), "_execute_next_action") as mocked:
+            record0 = self.backend.create_record("test_csv_output", vals)
+            # quick exec is off, we should not get any call
+            mocked.assert_not_called()
+            self.assertEqual(record0.edi_exchange_state, "new")
+        self.exchange_type_out.quick_exec = True
+        with mock.patch.object(type(model), "_execute_next_action") as mocked:
+            record0 = self.backend.create_record("test_csv_output", vals)
+            # quick exec is on, we should get a call
+            mocked.assert_called()
+            self.assertEqual(record0.edi_exchange_state, "new")
+
+    @mute_logger(*LOGGERS)
     def test_quick_exec_on_create_out(self):
         self.exchange_type_out.exchange_file_auto_generate = True
         self.exchange_type_out.quick_exec = True


### PR DESCRIPTION
edi_oca: extract _handle_new_output_exchange_records and replace _check_output_exchange_sync call

The aim is to handle records with the new extracted method _handle_new_output_exchange_records when the direction is 'output' and the edi.exchange.type is flagged with quick_exec

