### PR TITLE
[16.0][FW] edi_oca: extract _handle_new_output_exchange_records

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -401,13 +401,7 @@ class EDIBackend(models.Model):
             "EDI Exchange output sync: found %d new records to process.",
             len(new_records),
         )
-        for rec in new_records:
-            job1 = rec.delayable().action_exchange_generate()
-            if not skip_send:
-                # Chain send job.
-                # Raise prio to max to send the record out as fast as possible.
-                job1.on_done(rec.delayable(priority=0).action_exchange_send())
-            job1.delay()
+        self._handle_new_output_exchange_records(new_records, skip_send=skip_send)
 
         if skip_send:
             return
@@ -426,6 +420,15 @@ class EDIBackend(models.Model):
             else:
                 # TODO: run in job as well?
                 self._exchange_output_check_state(rec)
+
+    def _handle_new_output_exchange_records(self, new_records, skip_send=False):
+        for rec in new_records:
+            job1 = rec.delayable().action_exchange_generate()
+            if not skip_send:
+                # Chain send job.
+                # Raise prio to max to send the record out as fast as possible.
+                job1.on_done(rec.delayable(priority=0).action_exchange_send())
+            job1.delay()
 
     def _get_new_output_exchange_records(self, record_ids=None):
         return self.exchange_record_model.search(

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -276,8 +276,10 @@ class EDIExchangeRecord(models.Model):
         # according to their direction and status.
         # Let it decide.
         if self.type_id.direction == "output":
-            self.backend_id._check_output_exchange_sync(record_ids=self.ids)
+            self.backend_id._handle_new_output_exchange_records(self)
         else:
+            # TODO: do not rely on the cron method and create a
+            # specific handle method like it has been done for the output
             self.backend_id._check_input_exchange_sync(record_ids=self.ids)
 
     @api.constrains("backend_id", "type_id")

--- a/edi_oca/tests/test_quick_exec.py
+++ b/edi_oca/tests/test_quick_exec.py
@@ -59,6 +59,24 @@ class EDIQuickExecTestCase(EDIBackendCommonComponentRegistryTestCase):
             mocked.assert_not_called()
             self.assertEqual(record0.edi_exchange_state, "new")
 
+    def test_quick_exec(self):
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        model = self.env["edi.exchange.record"]
+        with mock.patch.object(type(model), "_execute_next_action") as mocked:
+            record0 = self.backend.create_record("test_csv_output", vals)
+            # quick exec is off, we should not get any call
+            mocked.assert_not_called()
+            self.assertEqual(record0.edi_exchange_state, "new")
+        self.exchange_type_out.quick_exec = True
+        with mock.patch.object(type(model), "_execute_next_action") as mocked:
+            record0 = self.backend.create_record("test_csv_output", vals)
+            # quick exec is on, we should get a call
+            mocked.assert_called()
+            self.assertEqual(record0.edi_exchange_state, "new")
+
     def test_quick_exec_on_create_out(self):
         self.exchange_type_out.exchange_file_auto_generate = True
         self.exchange_type_out.quick_exec = True


### PR DESCRIPTION
Port from 18.0 to 16.0:


https://github.com/OCA/edi-framework/pull/139