### PR TITLE
[16.0][FIX] edi_storage_oca: do not silently ignore OSError/FileNotFoundError

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -354,11 +354,20 @@ class EDIBackend(models.Model):
             exceptions.ValidationError,
         )
 
-    def _send_retryable_exceptions(self):
+    def _common_retryable_exceptions(self):
         # IOError is a base class for all connection errors
         # OSError is a base class for all errors
         # when dealing w/ internal or external systems or filesystems
         return (IOError, OSError)
+
+    def _receive_retryable_exceptions(self):
+        return self._common_retryable_exceptions()
+
+    def _process_retryable_exceptions(self):
+        return self._common_retryable_exceptions()
+
+    def _send_retryable_exceptions(self):
+        return self._common_retryable_exceptions()
 
     def _output_check_send(self, exchange_record):
         if exchange_record.direction != "output":
@@ -505,6 +514,14 @@ class EDIBackend(models.Model):
             error = _get_exception_msg()
             state = "input_processed_error"
             res = f"Error: {error}"
+        except self._process_retryable_exceptions() as err:
+            error = _get_exception_msg()
+            _logger.debug(
+                "%s process failed. To be retried.", exchange_record.identifier
+            )
+            raise RetryableJobError(
+                error, **exchange_record._job_retry_params()
+            ) from err
         else:
             error = None
             state = "input_processed"
@@ -563,6 +580,14 @@ class EDIBackend(models.Model):
             state = "input_receive_error"
             message = exchange_record._exchange_status_message("receive_ko")
             res = f"Input error: {error}"
+        except self._receive_retryable_exceptions() as err:
+            error = _get_exception_msg()
+            _logger.debug(
+                "%s receive failed. To be retried.", exchange_record.identifier
+            )
+            raise RetryableJobError(
+                error, **exchange_record._job_retry_params()
+            ) from err
         else:
             message = exchange_record._exchange_status_message("receive_ok")
             error = None

--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -548,7 +548,6 @@ class EDIBackend(models.Model):
         content = None
         try:
             content = self._exchange_receive(exchange_record)
-            # Ignore result of FileNotFoundError/OSError
             if content is not None:
                 exchange_record._set_file_content(content)
                 self._validate_data(exchange_record)

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -332,6 +332,42 @@ class EDIExchangeRecord(models.Model):
         self.ensure_one()
         return self.backend_id.exchange_receive(self)
 
+    def action_exchange_send_on_max_retries_reached(self):
+        self.ensure_one()
+        self.write(
+            {
+                "edi_exchange_state": "output_error_on_send",
+                "exchange_error": self.env.context.get("exc_info", "Error on Send"),
+                "exchanged_on": fields.Datetime.now(),
+            }
+        )
+        self._notify_error("send_ko")
+        return None
+
+    def action_exchange_process_on_max_retries_reached(self):
+        self.ensure_one()
+        self.write(
+            {
+                "edi_exchange_state": "input_processed_error",
+                "exchange_error": self.env.context.get("exc_info", "Error on Process"),
+                "exchanged_on": fields.Datetime.now(),
+            }
+        )
+        self._notify_error("process_ko")
+        return None
+
+    def action_exchange_receive_on_max_retries_reached(self):
+        self.ensure_one()
+        self.write(
+            {
+                "edi_exchange_state": "input_receive_error",
+                "exchange_error": self.env.context.get("exc_info", "Error on Receive"),
+                "exchanged_on": fields.Datetime.now(),
+            }
+        )
+        self._notify_error("receive_ko")
+        return None
+
     def exchange_create_ack_record(self, **kw):
         return self.exchange_create_child_record(
             exc_type=self.type_id.ack_type_id, **kw

--- a/edi_oca/tests/test_backend_jobs.py
+++ b/edi_oca/tests/test_backend_jobs.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from requests.exceptions import ConnectionError as ReqConnectionError
 
-from odoo.addons.queue_job.exception import RetryableJobError
+from odoo.addons.queue_job.exception import FailedJobError, RetryableJobError
 from odoo.addons.queue_job.tests.common import JobMixin
 
 from .common import EDIBackendCommonTestCase
@@ -77,6 +77,31 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
             with self.assertRaises(RetryableJobError):
                 job.perform()
 
+    def test_output_failed_record_on_max_retries_reached(self):
+        job_counter = self.job_counter()
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "edi_exchange_state": "output_pending",
+        }
+        record = self.backend.create_record("test_csv_output", vals)
+        record._set_file_content("ABC")
+        job = record.with_delay().action_exchange_send()
+        job_counter.search_created()
+        with mock.patch.object(type(self.backend), "_exchange_send") as mocked_1:
+            mocked_1.side_effect = ReqConnectionError("Connection broken")
+            job.exc_info = "Traceback of error:......"
+            job.max_retries = 1
+            # Job will be failed
+            with self.assertRaises(FailedJobError):
+                job.perform()
+            # But we want to check the record
+            try:
+                job.perform()
+            except FailedJobError:
+                self.assertEqual(record.edi_exchange_state, "output_error_on_send")
+                self.assertEqual(record.exchange_error, job.exc_info)
+
     def test_input(self):
         job_counter = self.job_counter()
         vals = {
@@ -132,3 +157,46 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
         # Check related jobs
         record.invalidate_recordset()
         self.assertEqual(created, self._get_related_jobs(record))
+
+    def test_input_failed_record_on_max_retries_reached(self):
+        # Test with receive exchange
+        job_counter = self.job_counter()
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "edi_exchange_state": "input_pending",
+        }
+        record = self.backend.create_record("test_csv_input", vals)
+        job = record.with_delay().action_exchange_receive()
+        job_counter.search_created()
+        with mock.patch.object(type(self.backend), "_exchange_receive") as mocked_1:
+            mocked_1.side_effect = ReqConnectionError("Connection broken")
+            job.exc_info = "Traceback of error:......receive error"
+            job.max_retries = 1
+            # Job will be failed
+            with self.assertRaises(FailedJobError):
+                job.perform()
+            # But we want to check the record
+            try:
+                job.perform()
+            except FailedJobError:
+                self.assertEqual(record.edi_exchange_state, "input_receive_error")
+                self.assertEqual(record.exchange_error, job.exc_info)
+        # Test with process exchange
+        record.edi_exchange_state = "input_received"
+        record._set_file_content("ABC")
+        job = record.with_delay().action_exchange_process()
+        job_counter.search_created()
+        with mock.patch.object(type(self.backend), "_exchange_process") as mocked_1:
+            mocked_1.side_effect = ReqConnectionError("Connection broken")
+            job.exc_info = "Traceback of error:......process error"
+            job.max_retries = 1
+            # Job will be failed
+            with self.assertRaises(FailedJobError):
+                job.perform()
+            # But we want to check the record
+            try:
+                job.perform()
+            except FailedJobError:
+                self.assertEqual(record.edi_exchange_state, "input_processed_error")
+                self.assertEqual(record.exchange_error, job.exc_info)

--- a/edi_storage_oca/components/receive.py
+++ b/edi_storage_oca/components/receive.py
@@ -14,4 +14,4 @@ class EDIStorageReceiveComponent(Component):
     _usage = "storage.receive"
 
     def receive(self):
-        return self._get_remote_file("pending", binary=True)
+        return self._get_remote_file("pending", binary=True, raise_if_not_found=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 odoo_test_helper
 responses
 xmlunittest
+odoo-addon-queue_job @ git+https://github.com/OCA/queue.git@refs/pull/674/head#subdirectory=setup/queue_job


### PR DESCRIPTION
Depends on https://github.com/OCA/queue/pull/674

if an OSError is raised, there can be different cases but it's likely a transient issue (e.g. connection error):

if we ignore it as currently:
Job won't fail
the exchange record will be incorrectly marked as "input_received" but with no data, which is not what we want
so we don't ignore it anymore:
Job will fail;
the record state will stay as "input_pending" (as exception won't be catched in [edi.backend:exchange_receive](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L537))
and as such, another action_exchange_receive Job will be created next time scheduled action "EDI exchange check input sync" runs, to try again to receive it, hopefully successfully this time
a RetryableJobError will be raised in order to retry it
if it sill can't succeed after max_retries, record state will be changed to "input_receive_error"
if a FileNotFoundError is raised, it's not a transient issue, so record should be marked as "input_receive_error":

to do so we don't ignore it anymore:
it will get catched in [edi.backend:exchange_receive](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L537) as a ["swallable"](https://github.com/OCA/edi-framework/blob/16.0/edi_oca/models/edi_backend.py#L548) (Final) error
record state will be changed to "input_receive_error"