### PR TITLE
[16.0][FIX] edit_storage_oca get_input_filenames return filename

### DIFF
--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -169,7 +169,7 @@ class EDIBackend(models.Model):
         relative_paths = utils.find_files(
             self.storage_id, pattern, full_input_dir_pending
         )
-        return [p.strip("/") for p in relative_paths]
+        return [os.path.basename(p.strip("/")) for p in relative_paths]
 
     def _storage_new_exchange_record_vals(self, file_name):
         return {


### PR DESCRIPTION
File names should not be prefixed by relative path