### PR TITLE
[18.0][FIX] edi-oca: error in component key

### DIFF
--- a/edi_oca/static/src/xml/widget_edi.xml
+++ b/edi_oca/static/src/xml/widget_edi.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
     <div t-name="edi_oca.EdiConfigurationWidget">
-        <t t-foreach="info" t-as="rule_id" t-key="rule_index">
+        <t t-foreach="info" t-as="rule_id" t-key="rule_id_index">
             <t t-set="rule" t-value="info[rule_id]" />
             <t t-if="rule.form">
                 <t t-set="btn" t-value="rule.form.btn" />


### PR DESCRIPTION
With the current implementation we had issues where t-key was undefined several times in the loop.
In a foreach we cannot have duplicated  t-key which means that we ran into tracebacks when opening views (only in debug mode).
I modified the t-key used to be more robust and avoid this kind of issues
