### PR TITLE
[18.0][FW] edi_oca: fwd ports from 16

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -385,6 +385,29 @@ class EDIBackend(models.Model):
         for backend in self:
             backend._check_output_exchange_sync(**kw)
 
+    def exchange_generate_send(self, recordset, skip_generate=False, skip_send=False):
+        """Generate and send output files for given records.
+
+        If both are False, the record will be generated and sent right away
+        with chained jobs.
+
+        If both `skip_generate` and `skip_send` are True, nothing will be done.
+        :param recordset: edi.exchange.record recordset
+        :param skip_generate: only send records
+        :param skip_send: only generate missing output
+        """
+        for rec in recordset:
+            if not skip_generate and not skip_send:
+                job1 = rec.delayable().action_exchange_generate()
+                # Chain send job.
+                # Raise prio to max to send the record out as fast as possible.
+                job1.on_done(rec.delayable(priority=0).action_exchange_send())
+                job1.delay()
+            elif skip_send:
+                rec.with_delay().action_exchange_generate()
+            elif not skip_send:
+                rec.with_delay(priority=0).action_exchange_send()
+
     def _check_output_exchange_sync(
         self, skip_send=False, skip_sent=True, record_ids=None
     ):

--- a/edi_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_oca/models/edi_exchange_consumer_mixin.py
@@ -294,3 +294,114 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
     def _edi_get_origin(self):
         self.ensure_one()
         return self.origin_exchange_record_id
+
+    # TODO: full unit test coverage
+    def _edi_send_via_edi(self, exchange_type, backend=None, force=False, **kw):
+        """Simply sending out a record via EDI.
+
+        If the exchange type requires an ack, it will be generated
+        if not already present.
+        """
+        exchange_record = None
+        # If we are sending an ack, we must check if we can generate it
+        if exchange_type.ack_for_type_ids:
+            # TODO: shall we raise an error if the ack is not possible?
+            if self._edi_can_generate_ack(exchange_type):
+                __, exchange_record = self._edi_get_or_create_ack_record(
+                    exchange_type, force=force
+                )
+        else:
+            exchange_record = self._edi_create_exchange_record(
+                exchange_type, backend=backend
+            )
+        if exchange_record:
+            exchange_record.action_exchange_generate_send(**kw)
+
+    # TODO: full unit test coverage
+    def _edi_can_generate_ack(self, exchange_type, force=False):
+        """Have to generate ack for this exchange type?
+
+        :param exchange_type: The exchange type to check.
+
+        It should be generated if:
+        - automation is not disabled and not forced
+        - origin exchange record is set (means it was originated by another record)
+        - origin exchange type is compatible with the configured ack types
+        """
+        if (self.disable_edi_auto and not force) or not self.origin_exchange_record_id:
+            return False
+        return self.origin_exchange_type_id in exchange_type.ack_for_type_ids
+
+    # TODO: full unit test coverage
+    def _edi_get_or_create_ack_record(self, exchange_type, backend=None, force=False):
+        """
+        Get or create a child record for the given exchange type.
+
+        If the record has not been sent out yet for whatever reason
+        (job delayed, job failed, send failed, etc)
+        we still want to generate a new up to date record to be sent.
+
+        :param exchange_type: The exchange type to create the record for.
+        :param force: If True, will force the creation of the record in case of ack type.
+        """
+        if not self._edi_can_generate_ack(exchange_type, force=force):
+            return False, False
+        parent = self._edi_get_origin()
+        # Filter acks that are not valued yet.
+        exchange_record = self._get_exchange_record(exchange_type).filtered(
+            lambda x: not x.exchange_file
+        )
+        created = False
+        # If the record has not been sent out yet for whatever reason
+        # (job delayed, job failed, send failed, etc)
+        # we still want to generate a new up to date record to be sent.
+        still_pending = exchange_record.edi_exchange_state in (
+            "output_pending",
+            "output_error_on_send",
+        )
+        if not exchange_record or still_pending:
+            vals = exchange_record._exchange_child_record_values()
+            vals["parent_id"] = parent.id
+            # NOTE: to fully automatize this,
+            # is recommended to enable `quick_exec` on the type
+            # otherwise records will have to wait for the cron to pass by.
+            exchange_record = self._edi_create_exchange_record(
+                exchange_type, backend=backend, vals=vals
+            )
+            created = True
+        return created, exchange_record
+
+    # TODO: full unit test coverage
+    def _edi_send_via_email(
+        self, ir_action, subtype_ref=None, partner_method=None, partners=None
+    ):
+        """Send EDI file via email using the provided action."""
+        # FIXME: missing generation of the record and adding it as an attachment
+        # In this case, the record should be generated immediately and attached to the email.
+        # An alternative is to generate the record and have a component to send via email.
+
+        # Retrieve context and composer model
+        ctx = ir_action.get("context", {})
+        composer_model = self.env[ir_action["res_model"]].with_context(ctx)
+
+        # Determine subtype and partner_ids dynamically based on model-specific logic
+        subtype = subtype_ref and self.env.ref(subtype_ref) or None
+        if not subtype:
+            return False
+
+        # THIS IS the part that should be delegated to a specific send component
+        # It could be also moved to its own module.
+        composer = composer_model.create({"subtype_id": subtype.id})
+        composer.onchange_template_id_wrapper()
+
+        # Dynamically retrieve partners based on the provided method or fallback to parameter
+        if partner_method and hasattr(self, partner_method):
+            composer.partner_ids = getattr(self, partner_method)().ids
+        elif partners:
+            composer.partner_ids = partners.ids
+        else:
+            return False
+
+        # Send the email
+        composer.send_mail()
+        return True

--- a/edi_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_oca/models/edi_exchange_consumer_mixin.py
@@ -329,7 +329,7 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         - origin exchange record is set (means it was originated by another record)
         - origin exchange type is compatible with the configured ack types
         """
-        if (self.disable_edi_auto and not force) or not self.origin_exchange_record_id:
+        if (self.edi_disable_auto and not force) or not self.origin_exchange_record_id:
             return False
         return self.origin_exchange_type_id in exchange_type.ack_for_type_ids
 
@@ -343,7 +343,7 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         we still want to generate a new up to date record to be sent.
 
         :param exchange_type: The exchange type to create the record for.
-        :param force: If True, will force the creation of the record in case of ack type.
+        :param force: If True, force creation of the record in case of ack type.
         """
         if not self._edi_can_generate_ack(exchange_type, force=force):
             return False, False
@@ -378,12 +378,14 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
     ):
         """Send EDI file via email using the provided action."""
         # FIXME: missing generation of the record and adding it as an attachment
-        # In this case, the record should be generated immediately and attached to the email.
-        # An alternative is to generate the record and have a component to send via email.
+        # In this case, the record should be generated immediately
+        # and attached to the email.
+        # An alternative is to generate the record
+        # and have a component to send via email.
 
         # Retrieve context and composer model
         ctx = ir_action.get("context", {})
-        composer_model = self.env[ir_action["res_model"]].with_context(ctx)
+        composer_model = self.env[ir_action["res_model"]].with_context(**ctx)
 
         # Determine subtype and partner_ids dynamically based on model-specific logic
         subtype = subtype_ref and self.env.ref(subtype_ref) or None
@@ -395,7 +397,7 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         composer = composer_model.create({"subtype_id": subtype.id})
         composer.onchange_template_id_wrapper()
 
-        # Dynamically retrieve partners based on the provided method or fallback to parameter
+        # Retrieve partners based on provided method or fallback to parameter
         if partner_method and hasattr(self, partner_method):
             composer.partner_ids = getattr(self, partner_method)().ids
         elif partners:

--- a/edi_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_oca/models/edi_exchange_consumer_mixin.py
@@ -314,7 +314,8 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
             exchange_record = self._edi_create_exchange_record(
                 exchange_type, backend=backend
             )
-        if exchange_record:
+        # If quick exec is on, `exchange_generate_send` already ran
+        if exchange_record and not exchange_type.quick_exec:
             exchange_record.action_exchange_generate_send(**kw)
 
     # TODO: full unit test coverage

--- a/edi_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_oca/models/edi_exchange_consumer_mixin.py
@@ -405,3 +405,20 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         # Send the email
         composer.send_mail()
         return True
+
+    def write(self, vals):
+        # Generic event to match a state change
+        # TODO: this can be added to component_event for models having the state field
+        state_change = "state" in vals and "state" in self._fields
+        if state_change:
+            for rec in self:
+                rec._event(f"on_edi_{self._table}_before_state_change").notify(
+                    rec, state=vals["state"]
+                )
+        res = super().write(vals)
+        if state_change:
+            for rec in self:
+                rec._event(f"on_edi_{self._table}_state_change").notify(
+                    rec, state=vals["state"]
+                )
+        return res

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -323,6 +323,9 @@ class EDIExchangeRecord(models.Model):
         self.ensure_one()
         return self.backend_id.exchange_send(self)
 
+    def action_exchange_generate_send(self, **kw):
+        return self.backend_id.exchange_generate_send(self, **kw)
+
     def action_exchange_process(self):
         self.ensure_one()
         return self.backend_id.exchange_process(self)

--- a/edi_oca/tests/test_consumer_mixin.py
+++ b/edi_oca/tests/test_consumer_mixin.py
@@ -5,7 +5,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import os
-import unittest
+from unittest import mock, skipIf
 
 from lxml import etree
 from odoo_test_helper import FakeModelLoader
@@ -17,8 +17,8 @@ from .common import EDIBackendCommonTestCase
 
 # This clashes w/ some setup (eg: run tests w/ pytest when edi_storage is installed)
 # If you still want to run `edi` tests w/ pytest when this happens, set this env var.
-@unittest.skipIf(os.getenv("SKIP_EDI_CONSUMER_CASE"), "Consumer test case disabled.")
 @tagged("at_install", "-post_install")
+@skipIf(os.getenv("SKIP_EDI_CONSUMER_CASE"), "Consumer test case disabled.")
 class TestConsumerMixinCase(EDIBackendCommonTestCase):
     @classmethod
     def _setup_env(cls):
@@ -198,3 +198,74 @@ result = not record._has_exchange_record(exchange_type, exchange_type.backend_id
             form = etree.fromstring(view["arch"])
             self.assertTrue(form.xpath("//field[@name='edi_has_form_config']"))
             self.assertTrue(form.xpath("//field[@name='edi_config']"))
+
+    # Don't care about real data processing here
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._validate_data")
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._exchange_generate")
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._exchange_send")
+    def test_edi_send_via_edi(self, mocked_send, mocked_generate, mocked_validate):
+        mocked_generate.return_value = "result"
+        self.assertEqual(self.consumer_record.exchange_record_count, 0)
+        self.consumer_record._edi_send_via_edi(
+            self.exchange_type_new, backend=self.backend
+        )
+        self.assertEqual(
+            self.consumer_record.exchange_record_ids[0].type_id, self.exchange_type_new
+        )
+        self.assertEqual(
+            self.consumer_record.exchange_record_ids[0]._get_file_content(), "result"
+        )
+
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._validate_data")
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._exchange_generate")
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._exchange_send")
+    def test_edi_send_via_edi_ack(self, mocked_send, mocked_generate, mocked_validate):
+        mocked_generate.return_value = "result"
+        vals = {
+            "model": self.consumer_record._name,
+            "res_id": self.consumer_record.id,
+        }
+        origin_exchange_record = self.backend.create_record(
+            self.exchange_type_in.code, vals
+        )
+        origin_exchange_record._set_file_content("original file")
+        self.consumer_record._edi_set_origin(origin_exchange_record)
+        self.assertEqual(self.consumer_record.exchange_record_count, 1)
+        # Type out is an hack for the original record, they will be linked
+        self.exchange_type_in.ack_type_id = self.exchange_type_out
+        self.consumer_record._edi_send_via_edi(
+            self.exchange_type_out, backend=self.backend
+        )
+        self.assertEqual(self.consumer_record.exchange_record_count, 2)
+        ack_record = self.consumer_record.exchange_record_ids[1]
+        self.assertEqual(ack_record.parent_id, origin_exchange_record)
+        self.assertEqual(ack_record.type_id, self.exchange_type_out)
+        self.assertEqual(ack_record._get_file_content(), "result")
+
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._validate_data")
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._exchange_generate")
+    @mock.patch("odoo.addons.edi_oca.models.edi_backend.EDIBackend._exchange_send")
+    def test_edi_send_via_edi_invalid_ack(
+        self, mocked_send, mocked_generate, mocked_validate
+    ):
+        mocked_generate.return_value = "result"
+        vals = {
+            "model": self.consumer_record._name,
+            "res_id": self.consumer_record.id,
+        }
+        origin_exchange_record = self.backend.create_record(
+            self.exchange_type_in.code, vals
+        )
+        origin_exchange_record._set_file_content("original file")
+        self.consumer_record._edi_set_origin(origin_exchange_record)
+        self.assertEqual(self.consumer_record.exchange_record_count, 1)
+        # Type out is an hack for another type, they will not be linked
+        self.exchange_type_in.ack_type_id = self.exchange_type_out_ack
+        self.consumer_record._edi_send_via_edi(
+            self.exchange_type_out, backend=self.backend
+        )
+        self.assertEqual(self.consumer_record.exchange_record_count, 2)
+        ack_record = self.consumer_record.exchange_record_ids[1]
+        self.assertFalse(ack_record.parent_id)
+        self.assertEqual(ack_record.type_id, self.exchange_type_out)
+        self.assertEqual(ack_record._get_file_content(), "result")


### PR DESCRIPTION
FWD port of https://github.com/OCA/edi-framework/pull/168 PART 1 (no edi.configuration)