### PR TITLE
[18.0] edi_exchange_template: complete specific tmpl lookup

### DIFF
--- a/edi_exchange_template_oca/models/edi_backend.py
+++ b/edi_exchange_template_oca/models/edi_backend.py
@@ -30,20 +30,14 @@ class EDIBackend(models.Model):
     def output_template_model(self):
         return self.env["edi.exchange.template.output"]
 
-    def _get_output_template(self, exchange_record, code=None):
+    def _get_output_template(self, exchange_record):
         """Retrieve output template.
 
         :param exchange_record: record to generate.
-        :param code: explicit template code to lookup.
         """
-        search = self.output_template_model.search
-        tmpl = None
-        code = code or exchange_record.type_id.code
-        if code:
-            domain = [("code", "=", code)]
-            tmpl = search(domain, limit=1)
-            if tmpl:
-                return tmpl
+        tmpl = exchange_record.type_id.output_template_id
+        if tmpl:
+            return tmpl
         tmpl = self._get_output_template_fallback(exchange_record)
         return tmpl
 

--- a/edi_exchange_template_oca/tests/test_backend_and_type.py
+++ b/edi_exchange_template_oca/tests/test_backend_and_type.py
@@ -75,25 +75,7 @@ class TestExchangeType(BaseCommon):
         }
         cls.record2 = cls.backend.create_record("test_type_out2", vals)
 
-    def test_get_template_by_code(self):
-        self.assertEqual(
-            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
-            self.tmpl_out1,
-        )
-        self.record1.type_id.code = self.tmpl_out1.code
-        self.assertEqual(
-            self.backend._get_output_template(self.record1), self.tmpl_out1
-        )
-        self.record2.type_id.code = self.tmpl_out2.code
-        self.assertEqual(
-            self.backend._get_output_template(self.record2), self.tmpl_out2
-        )
-
     def test_get_template_by_fallback(self):
-        self.assertEqual(
-            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
-            self.tmpl_out1,
-        )
         self.assertEqual(
             self.backend._get_output_template(self.record1), self.tmpl_out1
         )

--- a/edi_exchange_template_oca/tests/test_backend_and_type.py
+++ b/edi_exchange_template_oca/tests/test_backend_and_type.py
@@ -2,11 +2,10 @@
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
 
-from odoo.addons.base.tests.common import BaseCommon
 
-
-class TestExchangeType(BaseCommon):
+class TestExchangeType(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_exchange_template_oca/tests/test_edi_backend_output.py
+++ b/edi_exchange_template_oca/tests/test_edi_backend_output.py
@@ -171,10 +171,6 @@ class TestEDIBackendOutput(TestEDIBackendOutputBase):
             self.backend._get_output_template(self.record2), self.tmpl_out2
         )
         self.assertEqual(
-            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
-            self.tmpl_out1,
-        )
-        self.assertEqual(
             self.backend._get_output_template(self.record_json), self.tmpl_out_json
         )
 


### PR DESCRIPTION
Fix the behavior according to the feature ported from v14
and drop the deprecated lookup by code.

Missing work from https://github.com/OCA/edi-framework/pull/138