### PR TITLE
[18.0] edi_xml: move get_xml_handler from edi_sale_ubl

### DIFF
--- a/edi_sale_ubl_oca/tests/common.py
+++ b/edi_sale_ubl_oca/tests/common.py
@@ -9,16 +9,6 @@ import random
 from odoo.addons.sale_order_import_ubl.tests.common import get_test_data
 
 
-def get_xml_handler(backend, schema_path, model=None):
-    model = model or backend._name
-    return backend._find_component(
-        model,
-        ["edi.xml"],
-        work_ctx={"schema_path": schema_path},
-        safe=False,
-    )
-
-
 def flatten(txt):
     return "".join([x.strip() for x in txt.splitlines()])
 

--- a/edi_xml_oca/tests/common.py
+++ b/edi_xml_oca/tests/common.py
@@ -22,3 +22,13 @@ class XMLTestCaseMixin(xmlunittest.XmlTestMixin):
         path = os.path.join(os.path.dirname(__file__), "examples", filename)
         with open(path) as thefile:
             return thefile.read()
+
+
+def get_xml_handler(backend, schema_path, model=None):
+    model = model or backend._name
+    return backend._find_component(
+        model,
+        ["edi.xml"],
+        work_ctx={"schema_path": schema_path},
+        safe=False,
+    )


### PR DESCRIPTION
This helper func was really mis-placed.

Extracted from #179 