### PR TITLE
[18.0] edi_endpoint: fix migration to v18

### DIFF
--- a/edi_endpoint_oca/migrations/18.0.1.0.0/post-migrate.py
+++ b/edi_endpoint_oca/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Force update endpoint_route table.
+
+    New params like `readonly` should be added to the stored routes.
+    """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    model = env["edi.endpoint"]
+    records = model.sudo().search([])
+    records._handle_registry_sync()
+    _logger.info("Forced endpoint route sync on %s records", model._name)


### PR DESCRIPTION
A new route parameter has been introduced and for existing endpoints to work OOTB we must resync.

Companion https://github.com/OCA/web-api/pull/108