### PR TITLE
[18.0] edi_state: prevent access errors when using models

### DIFF
--- a/edi_state_oca/models/edi_exchange_type.py
+++ b/edi_state_oca/models/edi_exchange_type.py
@@ -26,5 +26,7 @@ class EDIExchangeType(models.Model):
 
     def get_state_for_model(self, model, code=None, default=False):
         assert code or default
-        wf = self.state_workflow_ids.filtered(lambda x: x.model_id.model == model)
+        wf = self.sudo().state_workflow_ids.filtered(
+            lambda x: x.model_id.model == model
+        )
         return wf.get_state(code) if code else wf.get_default_state()

--- a/edi_state_oca/models/edi_state_workflow.py
+++ b/edi_state_oca/models/edi_state_workflow.py
@@ -31,7 +31,7 @@ class EDIStateWorkflow(models.Model):
     )
 
     def is_valid_for_model(self, model_name):
-        return self.model_id.model == model_name
+        return self.sudo().model_id.model == model_name
 
     def get_default_state(self):
         return self.state_ids.filtered(lambda x: x.is_default)


### PR DESCRIPTION
You never know which user is go to use these features down the stack and it's easy that a given user does not have access to ir.model records.

We don't care about permissions here so it's perfectly safe to use sudo.