### PR TITLE
[FIX] edi_oca: prevent query error when empty recordset

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -233,6 +233,8 @@ class EDIExchangeRecord(models.Model):
         the first related record res_id and model as value.
         """
         self.env["edi.exchange.related.record"].flush_model()
+        if not self.ids:
+            return {}
         query, params = self._get_edi_first_related_record_query()
         self.env.cr.execute(query, params)
         return {


### PR DESCRIPTION
@simahawk only affects if you try to create manually an EDI record, but better to have it