### PR TITLE
[16.0][FIX] edi_oca: avoid copy model field on exchange records

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -45,6 +45,7 @@ class EDIExchangeRecord(models.Model):
         compute="_compute_record",
         inverse="_inverse_record",
         store=True,
+        copy=False,
     )
     res_id = fields.Many2oneReference(
         string="Record",


### PR DESCRIPTION
FP of https://github.com/OCA/edi/pull/1210

Set `copy=False` on `model` field to prevent records with model but no res_id, which caused visual errors in the `_search` function.