### PR TITLE
[18.0][FIX] edi_oca: avoid copy model field on exchange records

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -39,7 +39,7 @@ class EDIExchangeRecord(models.Model):
     )
     direction = fields.Selection(related="type_id.direction")
     backend_id = fields.Many2one(comodel_name="edi.backend", required=True)
-    model = fields.Char(index=True, required=False, readonly=True)
+    model = fields.Char(index=True, required=False, readonly=True, copy=False)
     res_id = fields.Many2oneReference(
         string="Record",
         index=True,


### PR DESCRIPTION
FP of https://github.com/OCA/edi/pull/1210

Set `copy=False` on `model` field to prevent records with model but no res_id, which caused visual errors in the `_search` function.