### PR TITLE
[18.0][FIX] edi_oca: cosmetic view changes

### DIFF
--- a/edi_oca/templates/exchange_mixin_buttons.xml
+++ b/edi_oca/templates/exchange_mixin_buttons.xml
@@ -9,7 +9,7 @@
             invisible="not edi_has_form_config"
         >
             <div>
-                <span class="pr-4"><i class="fa fa-retweet" /> EDI actions</span>
+                <span class="pe-4"><i class="fa fa-retweet" /> EDI actions</span>
                 <field name="edi_config" widget="edi_configuration" />
                 <field name="edi_has_form_config" invisible="1" />
             </div>

--- a/edi_oca/views/edi_exchange_type_rule_views.xml
+++ b/edi_oca/views/edi_exchange_type_rule_views.xml
@@ -62,7 +62,7 @@
                             string="Snippet"
                             groups="edi_oca.group_edi_advanced_settings_manager"
                         >
-                            <field name="enable_snippet" />
+                            <field name="enable_snippet" widget="ace" colspan="4" />
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
- [x] Add missing code widget to enable_snippet field.

Before:
<img width="650" height="419" alt="image" src="https://github.com/user-attachments/assets/2e0ee9c4-5da5-4065-9b99-94532a29d38e" />

After:
<img width="647" height="425" alt="image" src="https://github.com/user-attachments/assets/73aae9b9-fb74-46e0-9649-d82818b0a5da" />

- [x] Bootstrap 5 compatibility

Before:
<img width="620" height="280" alt="image" src="https://github.com/user-attachments/assets/3611b84c-7890-490e-af78-ad224ec97dbe" />

After:
<img width="424" height="278" alt="image" src="https://github.com/user-attachments/assets/09761e04-3d69-42c8-a242-5c5b282476a4" />
 
