### PR TITLE
[18.0] edi_oca: fix record form related_exchanges visibility

### DIFF
--- a/edi_core_oca/views/edi_exchange_record_views.xml
+++ b/edi_core_oca/views/edi_exchange_record_views.xml
@@ -164,7 +164,7 @@
                         <page
                             name="related_exchanges"
                             string="Related exchanges"
-                            invisible="not related_exchange_ids or not parent_id"
+                            invisible="not related_exchange_ids and not parent_id"
                         >
                             <group name="rel_exchanges">
                                 <field name="parent_id" />


### PR DESCRIPTION
The page was not visible in any case. The condition was wrong. It should be hidden if no related exchange nor parent is set.