### PR TITLE
[18.0][FIX] edi_core_oca: properly call model in _get_exec_handler

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -637,7 +637,7 @@ class EDIBackend(models.Model):
         model = exchange_record.type_id[f"{action}_model_id"]
         if model:
             ctx = self._get_record_env_ctx(exchange_record, action)
-            return getattr(self.env[model.model].with_context(**ctx), action)
+            return getattr(self.env[model].with_context(**ctx), action)
         raise EDINotImplementedError(
             self.env._("No handler for %(action)s", action=action)
         )


### PR DESCRIPTION
....