### PR TITLE
[18.0] edi_exchange_template: fix migration to 18.0.1.3.0

### DIFF
--- a/edi_exchange_template_oca/migrations/18.0.1.3.0/post-migrate.py
+++ b/edi_exchange_template_oca/migrations/18.0.1.3.0/post-migrate.py
@@ -3,7 +3,7 @@
 from openupgradelib import openupgrade
 
 
-@openupgrade.migrate
+@openupgrade.migrate()
 def migrate(env, version):
     env["edi.exchange.type"].search(
         [


### PR DESCRIPTION
Fix misuse of the decorator. Without this the migration is completely broken. 