### PR TITLE
[18.0] edi_core_oca: fix redundant info on related record

### DIFF
--- a/edi_core_oca/views/edi_exchange_record_views.xml
+++ b/edi_core_oca/views/edi_exchange_record_views.xml
@@ -135,22 +135,6 @@
                             <field name="ack_exchange_id" />
                             <field name="ack_received_on" />
                         </group>
-                        <group
-                            name="related_odoo_record"
-                            string="Related record"
-                            groups="base.group_no_one"
-                            invisible="res_id == 0"
-                        >
-                            <field name="res_id" readonly="1" />
-                            <field name="model" readonly="1" />
-                            <span
-                                class="text-warning"
-                                invisible="related_record_exists"
-                            >
-                                The related record is not available anymore.
-                                Consider deleting this record too or fixing its relation.
-                            </span>
-                        </group>
                     </group>
                     <notebook>
                         <page
@@ -196,6 +180,20 @@
                                     />
                                 </list>
                             </field>
+                            <group
+                                name="related_odoo_record"
+                                groups="base.group_no_one"
+                                invisible="res_id == 0"
+                            >
+                                <div
+                                    class="alert alert-danger"
+                                    role="alert"
+                                    invisible="related_record_exists"
+                                >
+                                    The related record is not available anymore.
+                                    Consider deleting this record too or fixing its relation.
+                                </div>
+                            </group>
                         </page>
                     </notebook>
                 </sheet>

--- a/edi_record_metadata_oca/views/edi_exchange_record.xml
+++ b/edi_record_metadata_oca/views/edi_exchange_record.xml
@@ -4,7 +4,7 @@
         <field name="model">edi.exchange.record</field>
         <field name="inherit_id" ref="edi_core_oca.edi_exchange_record_view_form" />
         <field name="arch" type="xml">
-            <page name="related_exchanges" position="after">
+            <page name="related_records" position="after">
                 <page name="metadata" string="Metadata" groups="base.group_no_one">
                     <group name="metadata">
                         <field name="metadata_display" />


### PR DESCRIPTION
There were 3 ways to access the related record.
Now there's only 2 but we still display the warning if the relation with the main record is broken.


**Before**

<img width="1191" height="809" alt="image" src="https://github.com/user-attachments/assets/8c5c4074-4475-489b-994c-3907fa8c599e" />



**After**

<img width="1550" height="1094" alt="edi-related-record-after" src="https://github.com/user-attachments/assets/39453dd2-a2b9-44b4-acab-d5e5df2e6d9d" />


Additional fix: record metadata tab position.