### PR TITLE
[18.0] edi_endpoint: fix create_exchange_record helper

### DIFF
--- a/edi_endpoint_oca/models/edi_endpoint.py
+++ b/edi_endpoint_oca/models/edi_endpoint.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Camptocamp SA
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import base64
+
 import werkzeug
 
 from odoo import _, api, exceptions, fields, models
@@ -32,18 +34,20 @@ class EDIEndpoint(models.Model):
         domain="[('backend_type_id','=', backend_type_id)]",
     )
 
-    # TODO: add unit tests
-
-    def create_exchange_record(self, file_content=None, **vals):
+    def create_exchange_record(self, file_content=None, encoding="utf-8", **vals):
         """Create an EDI exchange record from current endpoint.
 
         Just a shortcut.
         """
         self._check_endpoint_ready()
         vals["edi_endpoint_id"] = self.id
-        rec = self.backend_id.create_record(self.exchange_type_id.code, vals)
+
         if file_content:
-            rec._set_file_content(file_content)
+            if not isinstance(file_content, bytes):
+                file_content = bytes(file_content, encoding)
+            vals["exchange_file"] = base64.b64encode(file_content)
+
+        rec = self.backend_id.create_record(self.exchange_type_id.code, vals)
         return rec
 
     def _check_endpoint_ready(self, request=False):

--- a/edi_endpoint_oca/tests/test_edi_endpoint.py
+++ b/edi_endpoint_oca/tests/test_edi_endpoint.py
@@ -2,6 +2,8 @@
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import base64
+
 from odoo import exceptions
 
 from odoo.addons.endpoint.tests.common import CommonEndpoint
@@ -53,3 +55,8 @@ class TestEndpoint(CommonEndpoint):
     def test_sync(self):
         # FIXME: just testing if the method here is available on GH
         self.endpoint._handle_registry_sync()
+
+    def test_create_exchange_record_with_file_content(self):
+        content = "This is a test"
+        rec = self.endpoint.create_exchange_record(file_content=content)
+        self.assertEqual(base64.b64decode(rec.exchange_file).decode("utf-8"), content)


### PR DESCRIPTION
Setting the file content after creating the record might lead to errors when the exchange type is has quick_exec enabled. That's because the backend will try to process the file immediately on create but there's no file content yet.

Just populate the file content right away.