### PR TITLE
[18.0] edi_webservice_oca: fix component lookup permission

### DIFF
--- a/edi_webservice_oca/models/edi_backend.py
+++ b/edi_webservice_oca/models/edi_backend.py
@@ -12,22 +12,25 @@ class EdiBackend(models.Model):
 
     def _get_component_usage_candidates(self, exchange_record, key):
         candidates = super()._get_component_usage_candidates(exchange_record, key)
-        if not self.webservice_backend_id or key not in self._webservice_actions:
+        ws_backend = self.webservice_backend_id.sudo()
+        if not ws_backend or key not in self._webservice_actions:
             return candidates
         return [f"webservice.{key}"] + candidates
 
     def _component_match_attrs(self, exchange_record, key):
         # Override to inject `webservice_protocol` as match attribute
         res = super()._component_match_attrs(exchange_record, key)
-        if not self.webservice_backend_id or key not in self._webservice_actions:
+        ws_backend = self.webservice_backend_id.sudo()
+        if not ws_backend or key not in self._webservice_actions:
             return res
-        res["webservice_protocol"] = self.webservice_backend_id.protocol
+        res["webservice_protocol"] = ws_backend.protocol
         return res
 
     def _component_sort_key(self, component_class):
         res = super()._component_sort_key(component_class)
+        ws_backend = self.webservice_backend_id.sudo()
         # Override to give precedence by `webservice_protocol` when needed.
-        if not self.webservice_backend_id:
+        if not ws_backend:
             return res
         return (
             1 if getattr(component_class, "_webservice_protocol", False) else 0,

--- a/edi_webservice_oca/models/edi_backend.py
+++ b/edi_webservice_oca/models/edi_backend.py
@@ -28,7 +28,7 @@ class EdiBackend(models.Model):
 
     def _component_sort_key(self, component_class):
         res = super()._component_sort_key(component_class)
-        ws_backend = self.webservice_backend_id.sudo()
+        ws_backend = self.webservice_backend_id
         # Override to give precedence by `webservice_protocol` when needed.
         if not ws_backend:
             return res

--- a/edi_webservice_oca/tests/test_backend.py
+++ b/edi_webservice_oca/tests/test_backend.py
@@ -34,3 +34,15 @@ class TestEdiWebService(EDIBackendCommonTestCase):
     def test_components_without_ws(self):
         components = self.backend._get_component_usage_candidates(self.record, "send")
         self.assertNotIn("webservice.send", components)
+
+    def test_component_lookup_avg_user(self):
+        """Ensure normal users can run the component lookup methods."""
+        user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create({"name": "Test EDI WS User", "login": "test_edi_ws_perm_user"})
+        )
+        backend = self.backend.with_user(user)
+        backend.sudo().webservice_backend_id = self.webservice
+        backend._get_component_usage_candidates(self.record, "send")
+        backend._component_match_attrs(self.record, "send")


### PR DESCRIPTION
Avoid odoo.exceptions.AccessError when accessing webservice fields to match components.