### PR TITLE
[18.0] edi_core_oca: protect and track file content

### DIFF
--- a/edi_component_oca/tests/test_backend_output.py
+++ b/edi_component_oca/tests/test_backend_output.py
@@ -52,11 +52,14 @@ class EDIBackendTestOutputCase(EDIBackendCommonComponentRegistryTestCase):
         self.assertFalse(self.record.exchanged_on)
         with freeze_time("2020-10-21 10:00:00"):
             self.record.action_exchange_send()
-        self.assertTrue(FakeOutputSender.check_called_for(self.record))
-        self.assertRecordValues(self.record, [{"edi_exchange_state": "output_sent"}])
-        self.assertEqual(
-            fields.Datetime.to_string(self.record.exchanged_on), "2020-10-21 10:00:00"
-        )
+            self.assertTrue(FakeOutputSender.check_called_for(self.record))
+            self.assertRecordValues(
+                self.record, [{"edi_exchange_state": "output_sent"}]
+            )
+            self.assertEqual(
+                fields.Datetime.to_string(self.record.exchanged_on),
+                "2020-10-21 10:00:00",
+            )
 
     def test_send_record_with_error(self):
         self.record.write({"edi_exchange_state": "output_pending"})

--- a/edi_core_oca/models/edi_exchange_record.py
+++ b/edi_core_oca/models/edi_exchange_record.py
@@ -65,13 +65,21 @@ class EDIExchangeRecord(models.Model):
         compute="_compute_exchange_filename", readonly=False, store=True
     )
     exchange_filechecksum = fields.Char(
-        compute="_compute_exchange_filechecksum", store=True
+        compute="_compute_exchange_filechecksum",
+        store=True,
+        tracking=True,
+        readonly=True,
     )
     exchanged_on = fields.Datetime(
         help="Sent or received on this date.",
         compute="_compute_exchanged_on",
         store=True,
-        readonly=False,
+        readonly=True,
+    )
+    exchange_file_frozen = fields.Boolean(
+        help="Not allowed to change the file anymore.",
+        compute="_compute_exchange_file_frozen",
+        compute_sudo=True,
     )
     edi_exchange_state = fields.Selection(
         string="Exchange state",
@@ -171,6 +179,17 @@ class EDIExchangeRecord(models.Model):
         for rec in self:
             if rec.edi_exchange_state in ("input_received", "output_sent"):
                 rec.exchanged_on = fields.Datetime.now()
+
+    @api.depends("exchange_file", "edi_exchange_state")
+    def _compute_exchange_file_frozen(self):
+        for rec in self:
+            rec.exchange_file_frozen = bool(
+                rec.exchange_file
+                and rec.edi_exchange_state
+                in ("input_processed", "output_sent", "output_sent_and_processed")
+            ) and not self.env.user.has_group(
+                "edi_core_oca.group_edi_override_exchange_file_content"
+            )
 
     @api.constrains("edi_exchange_state")
     def _constrain_edi_exchange_state(self):

--- a/edi_core_oca/security/res_groups.xml
+++ b/edi_core_oca/security/res_groups.xml
@@ -8,4 +8,12 @@
             eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
         />
     </record>
+    <record id="group_edi_override_exchange_file_content" model="res.groups">
+        <field name="name">EDI Override Exchange File Content</field>
+        <field name="category_id" ref="base_edi.module_category_edi" />
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
 </odoo>

--- a/edi_core_oca/tests/test_backend_output.py
+++ b/edi_core_oca/tests/test_backend_output.py
@@ -69,13 +69,16 @@ class EDIBackendTestOutputCase(EDIBackendCommonTestCase):
         self.assertFalse(self.record.exchanged_on)
         with freeze_time("2020-10-21 10:00:00"):
             self.record.action_exchange_send()
-        self.assertTrue(
-            self.ExecutionAbstractModel.check_called_for(self.record, "send")
-        )
-        self.assertRecordValues(self.record, [{"edi_exchange_state": "output_sent"}])
-        self.assertEqual(
-            fields.Datetime.to_string(self.record.exchanged_on), "2020-10-21 10:00:00"
-        )
+            self.assertTrue(
+                self.ExecutionAbstractModel.check_called_for(self.record, "send")
+            )
+            self.assertRecordValues(
+                self.record, [{"edi_exchange_state": "output_sent"}]
+            )
+            self.assertEqual(
+                fields.Datetime.to_string(self.record.exchanged_on),
+                "2020-10-21 10:00:00",
+            )
 
     def test_send_record_with_error(self):
         self.record.write({"edi_exchange_state": "output_pending"})

--- a/edi_core_oca/tests/test_record.py
+++ b/edi_core_oca/tests/test_record.py
@@ -208,6 +208,23 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
         self.assertEqual(record0.exchange_filechecksum, checksum2)
         self.assertNotEqual(record0.exchange_filechecksum, checksum1)
 
+    def test_file_frozen(self):
+        filecontent = base64.b64encode(b"ABC")
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "exchange_file": filecontent,
+        }
+        record0 = self.backend.create_record("test_csv_output", vals)
+        bypass_group = "edi_core_oca.group_edi_override_exchange_file_content"
+        self.assertTrue(self.env.user.has_group(bypass_group))
+        self.assertFalse(record0.exchange_file_frozen)
+        record0.edi_exchange_state = "output_sent"
+        self.assertFalse(record0.exchange_file_frozen)
+        self.env.user.groups_id -= self.env.ref(bypass_group)
+        record0.invalidate_recordset()
+        self.assertTrue(record0.exchange_file_frozen)
+
     def test_related_records(self):
         vals = {
             "model": self.partner._name,

--- a/edi_core_oca/views/edi_exchange_record_views.xml
+++ b/edi_core_oca/views/edi_exchange_record_views.xml
@@ -123,11 +123,19 @@
                         </group>
                         <group name="status" string="Status">
                             <field name="exchanged_on" />
-                            <field name="exchange_file" filename="exchange_filename" />
-                            <field name="exchange_filename" invisible="exchange_file" />
+                            <field
+                                name="exchange_file"
+                                filename="exchange_filename"
+                                readonly="exchange_file_frozen"
+                            />
+                            <field
+                                name="exchange_filename"
+                                invisible="exchange_file"
+                                readonly="exchange_file_frozen"
+                            />
                             <field
                                 name="exchange_filechecksum"
-                                invisible="exchange_file"
+                                invisible="not exchange_file"
                             />
                         </group>
                         <group name="ack" string="ACK" invisible="not ack_expected">


### PR DESCRIPTION
So far the file could be edited in any state and w/o any trace of editing. This change brings:

* the file is frozen if it has been already processed or sent
* if you really need to change it you can force this by assigning the group ``group_edi_override_exchange_file_content`` to the user
* updates to the file are now tracked via checksum changes



<img width="1715" height="499" alt="edi-record-frozen-1" src="https://github.com/user-attachments/assets/0592228c-5ea7-44bc-969e-d63517d4721f" />

<img width="1620" height="580" alt="edi-record-frozen-2" src="https://github.com/user-attachments/assets/cbde6b0b-e4d8-4242-a8d0-1757a76fef8d" />

NOTE: The flag is visible only in debug mode.


**TODO**
- [ ] fix tests
- [ ] avoid tracking of checksum on create