### PR TITLE
[17.0][FIX] edi_oca: move ordering inside conditional block

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -617,9 +617,9 @@ class EDIExchangeRecord(models.Model):
             extend_ids = list(extend_query)
             result.extend(extend_ids[: limit - len(result)])
 
-        # Restore original ordering
-        result = [x for x in orig_ids if x in result]
         if set(orig_ids) != set(result):
+            # Restore original ordering
+            result = [x for x in orig_ids if x in result]
             # Create a virgin query
             query = self.browse(result)._as_query()
         return query


### PR DESCRIPTION
Fixes major performance issues in edi_exchange_record_view_tree when grouping is enabled. The limit parameter only applies to the number of displayed group lines, but the grouping logic fetches all matching records, causing unnecessary reordering of the entire dataset when set(orig_ids) == set(result).