### PR TITLE
[16.0][FIX] edi_oca _cron_check_output_exchange_sync no check on quick_exec

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -472,6 +472,7 @@ class EDIBackend(models.Model):
             ("type_id.direction", "=", "output"),
             ("edi_exchange_state", "=", "new"),
             ("exchange_file", "=", False),
+            ("type_id.quick_exec", "=", False),
         ]
         if record_ids:
             domain.append(("id", "in", record_ids))


### PR DESCRIPTION
Records with type quick_exec=True will be processed immediately without waiting for the cron to pass by.

Therefore there's no point to lookup for pending output exchange record with quick_exec here: 
https://github.com/OCA/edi-framework/blob/33ae2216c8361999af5cf5d5f7865adebf135c20/edi_oca/models/edi_backend.py#L397

https://github.com/OCA/edi-framework/blob/33ae2216c8361999af5cf5d5f7865adebf135c20/edi_oca/models/edi_backend.py#L436