### PR TITLE
[FIX] edi_storage_oca: Remove legacy storage component code

### DIFF
--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -59,27 +59,6 @@ class EDIBackend(models.Model):
         "Output error directory", help="Path to folder for error operations"
     )
 
-    def _get_component_usage_candidates(self, exchange_record, key):
-        candidates = super()._get_component_usage_candidates(exchange_record, key)
-        if not self.storage_id or key not in self._storage_actions:
-            return candidates
-        return [f"storage.{key}"] + candidates
-
-    def _component_match_attrs(self, exchange_record, key):
-        # Override to inject storage_type
-        res = super()._component_match_attrs(exchange_record, key)
-        if not self.storage_id or key not in self._storage_actions:
-            return res
-        res["storage_type"] = self.sudo().storage_id.protocol
-        return res
-
-    def _component_sort_key(self, component_class):
-        res = super()._component_sort_key(component_class)
-        # Override to give precedence by storage_type when needed.
-        if not self.storage_id:
-            return res
-        return (1 if getattr(component_class, "_storage_type", False) else 0,) + res
-
     def _storage_cron_check_pending_input(self, **kw):
         for backend in self:
             backend._storage_check_pending_input(**kw)


### PR DESCRIPTION
Remove remaining code that was colliding when edi_component_oca module is installed in the system and not proper configuration is taken into account.