### PR TITLE
[18.0][FIX] edi_storage_oca: ls whitespace filename with ftp protocol

### DIFF
--- a/edi_storage_oca/utils.py
+++ b/edi_storage_oca/utils.py
@@ -48,6 +48,8 @@ def list_files(storage, relative_path="", pattern=False):
     if pattern:
         relative_path = fs.sep.join([relative_path, pattern])
         return fs.glob(relative_path)
+    if fs.protocol == "ftp" and fs.ftp:
+        return fs.ftp.nlst(relative_path)
     return fs.ls(relative_path, detail=False)
 
 


### PR DESCRIPTION
The method fs.ls() fails to correctly parse FTP filenames with spaces. This change bypasses fs.ls for the FTP protocol and uses the underlying fs.ftp.nlst() method directly, which returns the correct full filenames.

Assume a directory /data exists on the FTP server containing a file named "my file.txt".

Actual output when using fs.ls with ftp protocol:
`['/data/file.txt'] `

Expected Output:
`['/data/my file.txt']`

Since this seems to be a bug in the fsspec library, I used fs.ftp.nlst() as a workaround. I've also reported the issue on their GitHub: https://github.com/fsspec/filesystem_spec/issues/1970