### PR TITLE
[18.0] edi_core: clarify quick exec usage

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -373,6 +373,15 @@ class EDIBackend(models.Model):
         ]
         if record_ids:
             domain.append(("id", "in", record_ids))
+        # By default, it's pointless to consider records with quick_exec
+        # because they will be executed right away when created.
+        domain.append(
+            (
+                "type_id.quick_exec",
+                "=",
+                self.env.context.get("edi__quick_exec", False),
+            )
+        )
         return domain
 
     def _output_pending_records_domain(self, skip_sent=True, record_ids=None):

--- a/edi_core_oca/models/edi_exchange_record.py
+++ b/edi_core_oca/models/edi_exchange_record.py
@@ -379,10 +379,11 @@ class EDIExchangeRecord(models.Model):
         # The backend already knows how to handle records
         # according to their direction and status.
         # Let it decide.
+        backend = self.backend_id.with_context(edi__quick_exec=True)
         if self.type_id.direction == "output":
-            self.backend_id._check_output_exchange_sync(record_ids=self.ids)
+            backend._check_output_exchange_sync(record_ids=self.ids)
         else:
-            self.backend_id._check_input_exchange_sync(record_ids=self.ids)
+            backend._check_input_exchange_sync(record_ids=self.ids)
 
     @api.constrains("backend_id", "type_id")
     def _constrain_backend(self):

--- a/edi_core_oca/models/edi_exchange_type.py
+++ b/edi_core_oca/models/edi_exchange_type.py
@@ -155,7 +155,9 @@ class EDIExchangeType(models.Model):
     quick_exec = fields.Boolean(
         string="Quick execution",
         help="When active, records of this type will be processed immediately "
-        "without waiting for the cron to pass by.",
+        "without waiting for the cron to pass by. "
+        "Requires auto generate flag to be active as well. "
+        "The cron will skip these records unless forced.",
     )
     partner_ids = fields.Many2many(
         string="Enabled for partners",

--- a/edi_core_oca/tests/test_edi_backend_cron.py
+++ b/edi_core_oca/tests/test_edi_backend_cron.py
@@ -87,14 +87,8 @@ class EDIBackendTestCronCase(EDIBackendCommonTestCase):
             # TODO: test better?
             self.assertFalse(rec.ack_exchange_id)
 
-    @mute_logger(*LOGGERS)
-    def test_exchange_generate_new_auto_send(self):
-        self.exchange_type_out.exchange_file_auto_generate = True
-        # No content ready to be sent, will get the content and send it
-        for rec in self.records:
-            self.assertEqual(rec.edi_exchange_state, "new")
-        self.backend._cron_check_output_exchange_sync()
-        for rec in self.records:
+    def _test_generate_new_auto_send(self, records):
+        for rec in records:
             self.assertEqual(rec.edi_exchange_state, "output_sent")
             self.assertTrue(
                 self.ExecutionAbstractModel.check_called_for(rec, "generate")
@@ -103,6 +97,26 @@ class EDIBackendTestCronCase(EDIBackendCommonTestCase):
                 rec._get_file_content(), self.ExecutionAbstractModel._call_key(rec)
             )
             self.assertTrue(self.ExecutionAbstractModel.check_called_for(rec, "send"))
+
+    @mute_logger(*LOGGERS)
+    def test_exchange_generate_new_auto_send(self):
+        self.exchange_type_out.exchange_file_auto_generate = True
+        # No content ready to be sent, will get the content and send it
+        for rec in self.records:
+            self.assertEqual(rec.edi_exchange_state, "new")
+        self.backend._cron_check_output_exchange_sync()
+        self._test_generate_new_auto_send(self.records)
+
+    @mute_logger(*LOGGERS)
+    def test_exchange_generate_new_quick_exec_skip_cron(self):
+        self.exchange_type_out.exchange_file_auto_generate = True
+        self.exchange_type_out.quick_exec = True
+        for rec in self.records:
+            self.assertEqual(rec.edi_exchange_state, "new")
+        # Records w/ quick exec should be skipped by the cron
+        self.backend._cron_check_output_exchange_sync()
+        for rec in self.records:
+            self.assertEqual(rec.edi_exchange_state, "new")
 
     @mute_logger(*LOGGERS)
     def test_exchange_generate_output_ready_auto_send(self):

--- a/edi_core_oca/views/edi_exchange_type_views.xml
+++ b/edi_core_oca/views/edi_exchange_type_views.xml
@@ -43,11 +43,17 @@
                             <field name="exchange_filename_pattern" />
                             <field name="exchange_filename_sequence_id" />
                             <field name="exchange_file_ext" />
-                            <field name="exchange_file_auto_generate" />
+                            <field
+                                name="exchange_file_auto_generate"
+                                invisible="direction != 'output'"
+                            />
+                            <field
+                                name="quick_exec"
+                                invisible="not exchange_file_auto_generate"
+                            />
                             <field name="ack_type_id" />
                             <field name="ack_for_type_ids" widget="many2many_tags" />
                             <field name="partner_ids" widget="many2many_tags" />
-                            <field name="quick_exec" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Ignore quick_exec types when running automated actions via cron. We assume that quick exec records will be executed right away. You still have the possibility to enforce this using edi__force_generate ctx key.

At the same time, make the usage more clear in the UI: quick exec is available only if you want to generate the output automatically.