### PR TITLE
[16.0] [FIX] edi_stock_oca: fix view

### DIFF
--- a/edi_stock_oca/views/res_partner.xml
+++ b/edi_stock_oca/views/res_partner.xml
@@ -9,7 +9,11 @@
         <field name="arch" type="xml">
             <!-- TODO: Move this conf inside `edi` page from edi_oca. -->
             <group name="inventory" position="after">
-                <group name="edi_configuration" string="EDI Configuration" />
+                <group
+                    name="edi_configuration"
+                    string="EDI Configuration"
+                    colspan="2"
+                />
             </group>
         </field>
     </record>


### PR DESCRIPTION
With this change, we fix the input field being too small.
<img width="470" height="314" alt="image" src="https://github.com/user-attachments/assets/dfd90518-081b-4187-9676-60a4681a2aac" />

@etobella 