### PR TITLE
[18.0][FIX] edi_core_oca: notify action completion based on exchange state

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -142,7 +142,8 @@ class EDIBackend(models.Model):
                         "exchange_error_traceback": traceback,
                     }
                 )
-        exchange_record.notify_action_complete("generate", message=message)
+        if exchange_record.edi_exchange_state == "output_pending":
+            exchange_record.notify_action_complete("generate", message=message)
         return message
 
     # TODO: unify to all other checkes that return something
@@ -258,7 +259,11 @@ class EDIBackend(models.Model):
                     "exchanged_on": fields.Datetime.now(),
                 }
             )
-        exchange_record.notify_action_complete("send", message=message)
+        if exchange_record.edi_exchange_state in [
+            "output_sent",
+            "output_sent_and_processed",
+        ]:
+            exchange_record.notify_action_complete("send", message=message)
         return res
 
     def _swallable_exceptions(self):
@@ -466,7 +471,8 @@ class EDIBackend(models.Model):
                 exchange_record._notify_error("process_ko")
             elif state == "input_processed":
                 exchange_record._notify_done()
-        exchange_record.notify_action_complete("process", message=message)
+        if exchange_record.edi_exchange_state == "input_processed":
+            exchange_record.notify_action_complete("process", message=message)
         return res
 
     def _exchange_process(self, exchange_record):
@@ -522,7 +528,8 @@ class EDIBackend(models.Model):
                     "exchanged_on": fields.Datetime.now(),
                 }
             )
-        exchange_record.notify_action_complete("receive", message=message)
+        if exchange_record.edi_exchange_state == "input_processed":
+            exchange_record.notify_action_complete("receive", message=message)
         return res
 
     def _exchange_receive_check(self, exchange_record):


### PR DESCRIPTION
CI failing because of FakeModelLoader; addressing it in  https://github.com/OCA/edi-framework/pull/238

**EDIT**
Cherry-picked the FakeModelLoader commit in here in order to let the CI run, but I will rebase it as soon the FakeModelLoader PR gets merged  https://github.com/OCA/edi-framework/pull/238