### PR TITLE
[18.0][FIX] res not initialized

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -436,6 +436,7 @@ class EDIBackend(models.Model):
         old_state = state = exchange_record.edi_exchange_state
         error = traceback = False
         message = None
+        res = None
         try:
             res = self._exchange_process(exchange_record)
         except self._swallable_exceptions() as err:


### PR DESCRIPTION
If we face EDINotImplementedError in exchange_process res is not initialized.

```python
Traceback (most recent call last):
  File "/odoo/external-src/edi-framework/edi_core_oca/models/edi_backend.py", line 461, in exchange_process
    res = self._exchange_process(exchange_record)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/edi-framework/edi_core_oca/models/edi_backend.py", line 501, in _exchange_process
    exchange_function = self._get_exec_handler(exchange_record, "process")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/edi-framework/edi_core_oca/models/edi_backend.py", line 685, in _get_exec_handler
    raise EDINotImplementedError(
odoo.addons.edi_core_oca.exceptions.EDINotImplementedError: No handler for process

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/odoo/external-src/queue/queue_job/controllers/main.py", line 116, in runjob
    self._try_perform_job(env, job)
  File "/odoo/external-src/queue/queue_job/controllers/main.py", line 39, in _try_perform_job
    job.perform()
  File "/odoo/external-src/queue/queue_job/job.py", line 495, in perform
    self.result = self.func(*tuple(self.args), **self.kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/queue/queue_job/models/base.py", line 216, in auto_delay_wrapper
    return auto_delay_wrapper.origin(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/edi-framework/edi_core_oca/models/edi_exchange_record.py", line 444, in action_exchange_process
    return self.backend_id.exchange_process(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/edi-framework/edi_core_oca/models/edi_backend.py", line 478, in exchange_process
    if res != "__sql_error__":
       ^^^
UnboundLocalError: cannot access local variable 'res' where it is not associated with a value
``` 