### PR TITLE
[17.0][FIX] edi_record_metadata_oca: rename get_metadata (ORM conflict)

### DIFF
--- a/edi_record_metadata_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_record_metadata_oca/models/edi_exchange_consumer_mixin.py
@@ -36,11 +36,11 @@ class EDIMetadataConsumerMixin(models.AbstractModel):
 
     def _edi_store_metadata(self, metadata):
         if self.origin_exchange_record_id:
-            self.origin_exchange_record_id.set_metadata(metadata)
+            self.origin_exchange_record_id.edi_set_metadata(metadata)
 
     @api.model
     def _edi_store_metadata_before_create(self, origin_id, metadata):
-        self.env["edi.exchange.record"].browse(origin_id).set_metadata(metadata)
+        self.env["edi.exchange.record"].browse(origin_id).edi_set_metadata(metadata)
 
     def _edi_get_metadata(self):
-        return self.origin_exchange_record_id.get_metadata()
+        return self.origin_exchange_record_id.edi_get_metadata()

--- a/edi_record_metadata_oca/models/edi_exchange_record.py
+++ b/edi_record_metadata_oca/models/edi_exchange_record.py
@@ -25,8 +25,8 @@ class EDIExchangeRecord(models.Model):
         for rec in self:
             rec.metadata_display = json.dumps(rec.metadata, sort_keys=True, indent=4)
 
-    def set_metadata(self, data):
+    def edi_set_metadata(self, data):
         self.metadata = data
 
-    def get_metadata(self):
+    def edi_get_metadata(self):
         return self.metadata

--- a/edi_record_metadata_oca/tests/test_metadata.py
+++ b/edi_record_metadata_oca/tests/test_metadata.py
@@ -35,7 +35,7 @@ class TestEDIMetadata(EDIBackendCommonTestCase):
         super().tearDownClass()
 
     def test_fields(self):
-        self.exc_record.set_metadata({"foo": "baz", "bar": "waa"})
+        self.exc_record.edi_set_metadata({"foo": "baz", "bar": "waa"})
         self.assertTrue(self.exc_record.metadata)
         self.assertTrue(self.exc_record.metadata_display)
 
@@ -48,7 +48,7 @@ class TestEDIMetadata(EDIBackendCommonTestCase):
             }
         )
         self.assertFalse(consumer_record._edi_get_metadata())
-        self.assertFalse(self.exc_record.get_metadata())
+        self.assertFalse(self.exc_record.edi_get_metadata())
 
     def test_store(self):
         vals = {
@@ -70,4 +70,4 @@ class TestEDIMetadata(EDIBackendCommonTestCase):
             "additional": True,
         }
         self.assertEqual(consumer_record._edi_get_metadata(), expected)
-        self.assertEqual(self.exc_record.get_metadata(), expected)
+        self.assertEqual(self.exc_record.edi_get_metadata(), expected)


### PR DESCRIPTION
`get_metadata()` is a built-in Odoo ORM method called by the "Debug > View Metadata" action. Defining it on `edi.exchange.record` overrode that behavior, causing a JS crash when opening the debug dialog:

  "Cannot read properties of undefined (reading 'id')"

Renamed to `edi_get_metadata()` / `edi_set_metadata()` (for consistency) and updated all callers.