### PR TITLE
[19.0] [IMP] edi_endpoint_oca: exec_mode=create_exchange_record

### DIFF
--- a/edi_endpoint_oca/README.rst
+++ b/edi_endpoint_oca/README.rst
@@ -45,6 +45,21 @@ Configuration
 
 Go to "EDI -> Config -> Endpoints".
 
+Exec modes
+----------
+
+Each endpoint must pick an "Exec mode" that decides how the incoming
+request is turned into work for the EDI framework:
+
+- **Create exchange record** (default): persists the raw HTTP body as a
+  new exchange record on the configured backend / exchange type and
+  returns ``{"status": "queued", "id": <identifier>}`` with HTTP 200.
+  Use this for "receive and queue" endpoints — no per-endpoint code
+  snippet is required, and request validation (e.g. JSON Schema) is
+  handled by the endpoint mixin before the handler runs.
+- **Execute code**: runs the user-provided code snippet, giving full
+  control over how the request is processed and what is returned.
+
 Bug Tracker
 ===========
 

--- a/edi_endpoint_oca/demo/edi_backend_demo.xml
+++ b/edi_endpoint_oca/demo/edi_backend_demo.xml
@@ -26,4 +26,15 @@ record = endpoint.create_exchange_record()
 result = {"response": Response("Created record: %s" % record.identifier)}
         </field>
     </record>
+
+    <record id="edi_endpoint_demo_2" model="edi.endpoint">
+        <field name="backend_id" ref="edi_backend_demo" />
+        <field name="backend_type_id" ref="edi_core_oca.demo_edi_backend_type" />
+        <field name="exchange_type_id" ref="edi_exchange_type_demo" />
+        <field name="name">EDI Demo Endpoint 2</field>
+        <field name="route">/demo/create</field>
+        <field name="request_method">POST</field>
+        <field name="request_content_type">application/json</field>
+        <field name="exec_mode">create_exchange_record</field>
+    </record>
 </odoo>

--- a/edi_endpoint_oca/models/edi_endpoint.py
+++ b/edi_endpoint_oca/models/edi_endpoint.py
@@ -66,6 +66,7 @@ class EDIEndpoint(models.Model):
             if not isinstance(file_content, bytes):
                 file_content = bytes(file_content, encoding)
             vals["exchange_file"] = base64.b64encode(file_content)
+            vals["edi_exchange_state"] = "input_received"
 
         rec = self.backend_id.create_record(self.exchange_type_id.code, vals)
         return rec

--- a/edi_endpoint_oca/models/edi_endpoint.py
+++ b/edi_endpoint_oca/models/edi_endpoint.py
@@ -33,6 +33,26 @@ class EDIEndpoint(models.Model):
         comodel_name="edi.exchange.type",
         domain="[('backend_type_id','=', backend_type_id)]",
     )
+    exec_mode = fields.Selection(default="create_exchange_record")
+
+    def _selection_exec_mode(self):
+        return super()._selection_exec_mode() + [
+            ("create_exchange_record", self.env._("Create exchange record")),
+        ]
+
+    def _handle_exec__create_exchange_record(self, request):
+        """Persist the raw HTTP body as an exchange record and acknowledge.
+
+        Covers the "receive and queue" case for incoming EDI endpoints,
+        avoiding the need for a per-endpoint code snippet.
+        """
+        record = self.create_exchange_record(
+            file_content=request.httprequest.get_data(),
+        )
+        return {
+            "payload": {"status": "queued", "id": record.identifier},
+            "status_code": 200,
+        }
 
     def create_exchange_record(self, file_content=None, encoding="utf-8", **vals):
         """Create an EDI exchange record from current endpoint.

--- a/edi_endpoint_oca/readme/CONFIGURE.md
+++ b/edi_endpoint_oca/readme/CONFIGURE.md
@@ -1,1 +1,15 @@
 Go to "EDI -\> Config -\> Endpoints".
+
+## Exec modes
+
+Each endpoint must pick an "Exec mode" that decides how the incoming
+request is turned into work for the EDI framework:
+
+- **Create exchange record** (default): persists the raw HTTP body as a
+  new exchange record on the configured backend / exchange type and
+  returns `{"status": "queued", "id": <identifier>}` with HTTP 200. Use
+  this for "receive and queue" endpoints — no per-endpoint code snippet
+  is required, and request validation (e.g. JSON Schema) is handled by
+  the endpoint mixin before the handler runs.
+- **Execute code**: runs the user-provided code snippet, giving full
+  control over how the request is processed and what is returned.

--- a/edi_endpoint_oca/static/description/index.html
+++ b/edi_endpoint_oca/static/description/index.html
@@ -380,12 +380,15 @@ framework.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a><ul>
+<li><a class="reference internal" href="#exec-modes" id="toc-entry-2">Exec modes</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -393,9 +396,24 @@ framework.</p>
 <div class="section" id="configuration">
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
 <p>Go to “EDI -&gt; Config -&gt; Endpoints”.</p>
+<div class="section" id="exec-modes">
+<h3><a class="toc-backref" href="#toc-entry-2">Exec modes</a></h3>
+<p>Each endpoint must pick an “Exec mode” that decides how the incoming
+request is turned into work for the EDI framework:</p>
+<ul class="simple">
+<li><strong>Create exchange record</strong> (default): persists the raw HTTP body as a
+new exchange record on the configured backend / exchange type and
+returns <tt class="docutils literal">{&quot;status&quot;: &quot;queued&quot;, &quot;id&quot;: &lt;identifier&gt;}</tt> with HTTP 200.
+Use this for “receive and queue” endpoints — no per-endpoint code
+snippet is required, and request validation (e.g. JSON Schema) is
+handled by the endpoint mixin before the handler runs.</li>
+<li><strong>Execute code</strong>: runs the user-provided code snippet, giving full
+control over how the request is processed and what is returned.</li>
+</ul>
+</div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/edi-framework/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -403,21 +421,21 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-3">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-4">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
 <ul class="simple">
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-5">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
 <ul class="simple">
 <li>Simone Orsi &lt;<a class="reference external" href="mailto:simone.orsi&#64;camptocamp.com">simone.orsi&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/edi_endpoint_oca/tests/common.py
+++ b/edi_endpoint_oca/tests/common.py
@@ -54,6 +54,17 @@ class EDIEndpointTestMixin:
             )
             or cls._get_endpoint()
         )
+        cls.endpoint_create_record = (
+            cls.Endpoint.search(
+                [
+                    ("route", "=", "/edi/demo/create"),
+                    ("backend_type_id", "=", cls.backend_type.id),
+                    ("exchange_type_id", "=", cls.exchange_type.id),
+                ],
+                limit=1,
+            )
+            or cls._get_endpoint_create_record()
+        )
 
     @classmethod
     def _get_backend_type(cls):
@@ -100,6 +111,21 @@ class EDIEndpointTestMixin:
                     'result = {"response": Response("'
                     'Created record: %s" % record.identifier)}'
                 ),
+            }
+        )
+
+    @classmethod
+    def _get_endpoint_create_record(cls):
+        return cls.env["edi.endpoint"].create(
+            {
+                "name": "EDI Demo Endpoint 2",
+                "backend_id": cls.backend.id,
+                "backend_type_id": cls.backend_type.id,
+                "exchange_type_id": cls.exchange_type.id,
+                "route": "/demo/create",
+                "request_method": "POST",
+                "request_content_type": "application/json",
+                "exec_mode": "create_exchange_record",
             }
         )
 

--- a/edi_endpoint_oca/tests/test_edi_endpoint.py
+++ b/edi_endpoint_oca/tests/test_edi_endpoint.py
@@ -29,15 +29,15 @@ class TestEndpoint(EDIEndpointCommonTestCase):
 
     def test_endpoint_count(self):
         backend = self.endpoint.backend_id
-        self.assertEqual(backend.endpoints_count, 1)
+        initial = backend.endpoints_count
         rec = self.endpoint.copy(
             {
                 "route": "/another",
             }
         )
-        self.assertEqual(backend.endpoints_count, 2)
+        self.assertEqual(backend.endpoints_count, initial + 1)
         rec.active = False
-        self.assertEqual(backend.endpoints_count, 1)
+        self.assertEqual(backend.endpoints_count, initial)
 
     def test_archive_check(self):
         backend = self.endpoint.backend_id

--- a/edi_endpoint_oca/tests/test_edi_endpoint_controller.py
+++ b/edi_endpoint_oca/tests/test_edi_endpoint_controller.py
@@ -57,5 +57,5 @@ class EDIEndpointHttpCase(HttpCase, EDIEndpointTestMixin):
         self.assertEqual(len(capture.records), 1)
         record = capture.records
         self.assertEqual(record.identifier, payload["id"])
-        self.assertEqual(record.edi_exchange_state, "new")
+        self.assertEqual(record.edi_exchange_state, "input_received")
         self.assertEqual(base64.b64decode(record.exchange_file), body)

--- a/edi_endpoint_oca/tests/test_edi_endpoint_controller.py
+++ b/edi_endpoint_oca/tests/test_edi_endpoint_controller.py
@@ -2,10 +2,12 @@
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import base64
+import json
 import os
 import unittest
 
-from odoo.tests.common import HttpCase
+from odoo.tests import HttpCase, RecordCapturer
 
 from .common import EDIEndpointTestMixin
 
@@ -17,18 +19,18 @@ class EDIEndpointHttpCase(HttpCase, EDIEndpointTestMixin):
         super().setUpClass()
         cls._setup_env()
         cls._setup_records()
-        # Sync only the endpoint under test to avoid re-registering unrelated
+        # Sync only the endpoints under test to avoid re-registering unrelated
         # demo routes that may already exist in the route registry.
-        cls.endpoint._handle_registry_sync()
+        (cls.endpoint | cls.endpoint_create_record)._handle_registry_sync()
 
     def tearDown(self):
         # Clear routing cache so each test starts clean
         self.env.registry.clear_cache("routing")
         super().tearDown()
 
-    def _make_request(self, route, headers=None):
+    def _make_request(self, route, headers=None, data=None):
         headers = dict(headers or {})
-        return self.url_open(route, headers=headers, timeout=60)
+        return self.url_open(route, headers=headers, data=data, timeout=60)
 
     def test_call1(self):
         endpoint = "/edi/demo/try"
@@ -39,3 +41,21 @@ class EDIEndpointHttpCase(HttpCase, EDIEndpointTestMixin):
         response = self._make_request(endpoint)
         self.assertEqual(response.status_code, 200)
         self.assertIn("Created record:", response.content.decode())
+
+    def test_handle_exec_create_exchange_record(self):
+        self.authenticate("admin", "admin")
+        body = json.dumps({"hello": "world"}).encode()
+        with RecordCapturer(self.env["edi.exchange.record"], []) as capture:
+            response = self._make_request(
+                "/edi/demo/create",
+                headers={"Content-Type": "application/json"},
+                data=body,
+            )
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "queued")
+        self.assertEqual(len(capture.records), 1)
+        record = capture.records
+        self.assertEqual(record.identifier, payload["id"])
+        self.assertEqual(record.edi_exchange_state, "new")
+        self.assertEqual(base64.b64decode(record.exchange_file), body)


### PR DESCRIPTION
Added a new default exec_mode for EDI exchange records: `create_exchange_record`

This mode will dump the request body as-is into the exchange record content for a later processing.