### PR TITLE
[19.0][IMP] edi_*_oca: skip exchange types w/o handler in cron domains

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -403,6 +403,8 @@ class EDIBackend(models.Model):
             ("backend_id", "=", self.id),
             ("type_id.exchange_file_auto_generate", "=", True),
             ("type_id.direction", "=", "output"),
+            ("type_id.generate_model_id", "!=", False),
+            ("type_id.send_model_id", "!=", False),
             ("edi_exchange_state", "=", "new"),
             ("exchange_file", "=", False),
         ]
@@ -430,6 +432,7 @@ class EDIBackend(models.Model):
             states += ("output_sent",)
         domain = [
             ("type_id.direction", "=", "output"),
+            ("type_id.send_model_id", "!=", False),
             ("backend_id", "=", self.id),
             ("edi_exchange_state", "in", states),
         ]
@@ -636,6 +639,7 @@ class EDIBackend(models.Model):
         domain = [
             ("backend_id", "=", self.id),
             ("type_id.direction", "=", "input"),
+            ("type_id.receive_model_id", "!=", False),
             ("edi_exchange_state", "=", "input_pending"),
             ("exchange_file", "=", False),
         ]
@@ -648,6 +652,7 @@ class EDIBackend(models.Model):
         domain = [
             ("backend_id", "=", self.id),
             ("type_id.direction", "=", "input"),
+            ("type_id.process_model_id", "!=", False),
             ("edi_exchange_state", "in", states),
         ]
         if record_ids:

--- a/edi_core_oca/models/edi_exchange_type.py
+++ b/edi_core_oca/models/edi_exchange_type.py
@@ -261,6 +261,32 @@ class EDIExchangeType(models.Model):
     def set_settings(self, val):
         self.advanced_settings_edit = val
 
+    @api.constrains(
+        "direction",
+        "send_model_id",
+        "process_model_id",
+        "generate_model_id",
+        "exchange_file_auto_generate",
+    )
+    def _check_direction_handlers(self):
+        for rec in self:
+            if rec.direction == "output":
+                if not rec.send_model_id:
+                    raise exceptions.ValidationError(
+                        self.env._("Output exchange types require a Sender handler.")
+                    )
+                if rec.exchange_file_auto_generate and not rec.generate_model_id:
+                    raise exceptions.ValidationError(
+                        self.env._(
+                            "Output exchange types with 'Auto Generate' enabled "
+                            "require a Generator handler."
+                        )
+                    )
+            elif rec.direction == "input" and not rec.process_model_id:
+                raise exceptions.ValidationError(
+                    self.env._("Input exchange types require a Processor handler.")
+                )
+
     @api.constrains("backend_id", "backend_type_id")
     def _check_backend(self):
         for rec in self:

--- a/edi_core_oca/models/edi_oca_handler.py
+++ b/edi_core_oca/models/edi_oca_handler.py
@@ -59,3 +59,26 @@ class EdiOcaHandlerCheck(models.AbstractModel):
 
     def check(self, exchange_record):
         pass
+
+
+class EdiOcaHandlerNoop(models.AbstractModel):
+    """No-op implementation of every EDI handler role.
+
+    ``edi.exchange.type`` requires handlers matching its direction (see
+    ``_check_direction_handlers``) but ``edi_core_oca`` ships no concrete
+    implementation. This handler performs no action and can be referenced by
+    demo/showcase exchange types, or used as a placeholder until a real
+    handler is configured.
+    """
+
+    _name = "edi.oca.handler.noop"
+    _inherit = [
+        "edi.oca.handler.generate",
+        "edi.oca.handler.input.validate",
+        "edi.oca.handler.output.validate",
+        "edi.oca.handler.send",
+        "edi.oca.handler.receive",
+        "edi.oca.handler.process",
+        "edi.oca.handler.check",
+    ]
+    _description = "EDI OCA Handler No-op"

--- a/edi_core_oca/tests/common.py
+++ b/edi_core_oca/tests/common.py
@@ -5,6 +5,7 @@
 
 import os
 
+from odoo.orm.model_classes import add_to_registry
 from odoo.tests.common import TransactionCase
 
 
@@ -19,6 +20,24 @@ class EDIBackendTestMixin:
     def _setup_env(cls, ctx=None):
         ctx = ctx or {}
         cls.env = cls.env(context=cls._setup_context(**ctx))
+        # Register EdiTestExecution early so _create_exchange_type can set default
+        # handler models — the new @api.constrains on edi.exchange.type requires
+        # send_model_id (output) and process_model_id (input) to be set.
+        # Guard prevents double-registration when individual test classes also call
+        # add_to_registry; pop() in cleanup is safe even if __delitem__ already ran.
+        if "edi.framework.test.execution" not in cls.registry:
+            from .fake_models import EdiTestExecution
+
+            add_to_registry(cls.registry, EdiTestExecution)
+            cls.registry._setup_models__(cls.env.cr, ["edi.framework.test.execution"])
+            cls.registry.init_models(
+                cls.env.cr, ["edi.framework.test.execution"], {"models_to_check": True}
+            )
+            cls.addClassCleanup(
+                lambda: cls.registry.__delitem__("edi.framework.test.execution")
+                if "edi.framework.test.execution" in cls.registry
+                else None
+            )
 
     @classmethod
     def _setup_records(cls):
@@ -84,6 +103,19 @@ class EDIBackendTestMixin:
 
     @classmethod
     def _create_exchange_type(cls, **kw):
+        # Mirror the pattern in edi_component_oca/tests/common.py: provide default
+        # handler models so every test exchange type satisfies the new constraint.
+        # Callers can override individual fields by passing explicit values.
+        if "edi.framework.test.execution" in cls.registry:
+            handler_model = cls.env["ir.model"]._get("edi.framework.test.execution")
+            if handler_model:
+                kw.setdefault("receive_model_id", handler_model.id)
+                kw.setdefault("generate_model_id", handler_model.id)
+                kw.setdefault("input_validate_model_id", handler_model.id)
+                kw.setdefault("output_validate_model_id", handler_model.id)
+                kw.setdefault("send_model_id", handler_model.id)
+                kw.setdefault("process_model_id", handler_model.id)
+                kw.setdefault("check_model_id", handler_model.id)
         model = cls.env["edi.exchange.type"]
         vals = {
             "name": "Test CSV exchange",

--- a/edi_core_oca/tests/common.py
+++ b/edi_core_oca/tests/common.py
@@ -106,16 +106,23 @@ class EDIBackendTestMixin:
         # Mirror the pattern in edi_component_oca/tests/common.py: provide default
         # handler models so every test exchange type satisfies the new constraint.
         # Callers can override individual fields by passing explicit values.
-        if "edi.framework.test.execution" in cls.registry:
-            handler_model = cls.env["ir.model"]._get("edi.framework.test.execution")
-            if handler_model:
-                kw.setdefault("receive_model_id", handler_model.id)
-                kw.setdefault("generate_model_id", handler_model.id)
-                kw.setdefault("input_validate_model_id", handler_model.id)
-                kw.setdefault("output_validate_model_id", handler_model.id)
-                kw.setdefault("send_model_id", handler_model.id)
-                kw.setdefault("process_model_id", handler_model.id)
-                kw.setdefault("check_model_id", handler_model.id)
+        # When the fake execution model is not registered (test classes that
+        # skip _setup_env), fall back to the no-op handler shipped by the
+        # module so the constraint is still satisfied.
+        handler_model_name = (
+            "edi.framework.test.execution"
+            if "edi.framework.test.execution" in cls.registry
+            else "edi.oca.handler.noop"
+        )
+        handler_model = cls.env["ir.model"]._get(handler_model_name)
+        if handler_model:
+            kw.setdefault("receive_model_id", handler_model.id)
+            kw.setdefault("generate_model_id", handler_model.id)
+            kw.setdefault("input_validate_model_id", handler_model.id)
+            kw.setdefault("output_validate_model_id", handler_model.id)
+            kw.setdefault("send_model_id", handler_model.id)
+            kw.setdefault("process_model_id", handler_model.id)
+            kw.setdefault("check_model_id", handler_model.id)
         model = cls.env["edi.exchange.type"]
         vals = {
             "name": "Test CSV exchange",

--- a/edi_core_oca/tests/fake_models.py
+++ b/edi_core_oca/tests/fake_models.py
@@ -34,6 +34,7 @@ class EdiExchangeConsumerTest(models.Model):
 class EdiTestExecution(models.AbstractModel):
     _name = "edi.framework.test.execution"
     _inherit = [
+        "edi.oca.handler.generate",
         "edi.oca.handler.process",
         "edi.oca.handler.check",
         "edi.oca.handler.send",

--- a/edi_core_oca/tests/test_backend_base.py
+++ b/edi_core_oca/tests/test_backend_base.py
@@ -93,9 +93,15 @@ class EDIBackendTestCaseBase(EDIBackendCommonTestCase):
         self._test_get_handler(user=user)
 
     def test_get_handler_no_handler(self):
-        self.exchange_type_in.process_model_id = False
-        self.exchange_type_in.input_validate_model_id = False
-        self.exchange_type_in.receive_model_id = False
+        self.env.cr.execute(
+            """UPDATE edi_exchange_type
+               SET process_model_id = NULL,
+                   input_validate_model_id = NULL,
+                   receive_model_id = NULL
+               WHERE id = %s""",
+            [self.exchange_type_in.id],
+        )
+        self.exchange_type_in.invalidate_recordset()
         vals = {
             "model": self.partner._name,
             "res_id": self.partner.id,

--- a/edi_core_oca/views/edi_exchange_type_views.xml
+++ b/edi_core_oca/views/edi_exchange_type_views.xml
@@ -83,6 +83,7 @@
                                 <field
                                     name="process_model_id"
                                     options="{'no_create': True}"
+                                    required="direction == 'input'"
                                 />
                                 <field
                                     name="input_validate_model_id"
@@ -96,10 +97,12 @@
                                 <field
                                     name="generate_model_id"
                                     options="{'no_create': True}"
+                                    required="direction == 'output' and exchange_file_auto_generate"
                                 />
                                 <field
                                     name="send_model_id"
                                     options="{'no_create': True}"
+                                    required="direction == 'output'"
                                 />
                                 <field
                                     name="output_validate_model_id"

--- a/edi_endpoint_oca/demo/edi_backend_demo.xml
+++ b/edi_endpoint_oca/demo/edi_backend_demo.xml
@@ -10,6 +10,7 @@
         <field name="code">demo_endpoint</field>
         <field name="backend_type_id" ref="edi_core_oca.demo_edi_backend_type" />
         <field name="direction">input</field>
+        <field name="process_model_id" ref="edi_core_oca.model_edi_oca_handler_noop" />
     </record>
 
     <record id="edi_endpoint_demo_1" model="edi.endpoint">

--- a/edi_endpoint_oca/tests/common.py
+++ b/edi_endpoint_oca/tests/common.py
@@ -86,12 +86,16 @@ class EDIEndpointTestMixin:
 
     @classmethod
     def _get_exchange_type(cls):
+        # The no-op handler satisfies the _check_direction_handlers constraint
+        # (input types need process_model_id).
+        handler_model = cls.env["ir.model"]._get("edi.oca.handler.noop")
         return cls.env["edi.exchange.type"].create(
             {
                 "name": "EDI exchange demo",
                 "code": "demo_endpoint",
                 "backend_type_id": cls.backend_type.id,
                 "direction": "input",
+                "process_model_id": handler_model.id,
             }
         )
 

--- a/edi_purchase_oca/demo/edi_exchange_type.xml
+++ b/edi_purchase_oca/demo/edi_exchange_type.xml
@@ -6,6 +6,7 @@
         <field name="name">Demo Purchase Order out</field>
         <field name="code">demo_PurchaseOrder_out</field>
         <field name="direction">output</field>
+        <field name="send_model_id" ref="edi_core_oca.model_edi_oca_handler_noop" />
         <field name="exchange_filename_pattern">{record_name}-{type.code}-{dt}</field>
         <field name="exchange_file_ext">xml</field>
     </record>

--- a/edi_queue_oca/tests/test_backend_output_jobs.py
+++ b/edi_queue_oca/tests/test_backend_output_jobs.py
@@ -4,6 +4,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 
+from odoo.orm.model_classes import add_to_registry
 from odoo.tests import tagged
 
 from odoo.addons.edi_core_oca.tests.common import EDIBackendCommonTestCase
@@ -12,6 +13,21 @@ from odoo.addons.queue_job.tests.common import trap_jobs
 
 @tagged("-at_install", "post_install")
 class EDIBackendTestOutputJobsCase(EDIBackendCommonTestCase):
+    @classmethod
+    def _setup_records(cls):  # pylint:disable=missing-return
+        super()._setup_records()
+        from odoo.addons.edi_core_oca.tests.fake_models import EdiTestExecution
+
+        add_to_registry(cls.registry, EdiTestExecution)
+        cls.registry._setup_models__(cls.env.cr, ["edi.framework.test.execution"])
+        cls.registry.init_models(
+            cls.env.cr, ["edi.framework.test.execution"], {"models_to_check": True}
+        )
+        cls.addClassCleanup(cls.registry.__delitem__, "edi.framework.test.execution")
+        model = cls.env["ir.model"]._get("edi.framework.test.execution")
+        cls.exchange_type_out.generate_model_id = model
+        cls.exchange_type_out.send_model_id = model
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_sale_oca/demo/edi_exchange_type.xml
+++ b/edi_sale_oca/demo/edi_exchange_type.xml
@@ -6,6 +6,7 @@
         <field name="name">Demo Sale Order Response</field>
         <field name="code">demo_SaleOrder_out</field>
         <field name="direction">output</field>
+        <field name="send_model_id" ref="edi_core_oca.model_edi_oca_handler_noop" />
         <field name="exchange_filename_pattern">{record_name}-{type.code}-{dt}</field>
         <field name="exchange_file_ext">xml</field>
     </record>
@@ -17,6 +18,7 @@
         <field name="name">Demo Sale Order</field>
         <field name="code">demo_SaleOrder_in</field>
         <field name="direction">input</field>
+        <field name="process_model_id" ref="edi_core_oca.model_edi_oca_handler_noop" />
         <field name="exchange_file_ext">xml</field>
     </record>
 </odoo>


### PR DESCRIPTION
Noticed while developing that when a exchange type is not linked to a handler and the EDINotImplementedError is raised, a DB rollback takes places undoing all previous work. 

To ensure that skipping not handled exchanges  does not break anything outside the cron scope I had to slightly change the exchange_generate_send method.

CC @etobella @simahawk @ForgeFlow 