### PR TITLE
[18.0][FIX] edi_storage_oca: raise error if file is missing when performing receive

### DIFF
--- a/edi_storage_oca/models/edi_oca_storage_handler.py
+++ b/edi_storage_oca/models/edi_oca_storage_handler.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import PurePath
 
 from odoo import models
+from odoo.exceptions import UserError
 
 from .. import utils
 
@@ -34,7 +35,9 @@ class EdiOcaStorageHandler(models.AbstractModel):
         utils.add_file(exchange_record.backend_id.storage_id, path.as_posix(), filedata)
 
     def receive(self, exchange_record):
-        return self._get_remote_file(exchange_record, "pending", binary=True)
+        return self._get_remote_file(
+            exchange_record, "pending", binary=True, raise_if_missing=True
+        )
 
     def _dir_by_state(self, backend, direction, state):
         """Return remote directory path by direction and state.
@@ -61,11 +64,21 @@ class EdiOcaStorageHandler(models.AbstractModel):
         )
         return path
 
-    def _get_remote_file(self, exchange_record, state, filename=None, binary=False):
+    def _get_remote_file(
+        self,
+        exchange_record,
+        state,
+        filename=None,
+        binary=False,
+        raise_if_missing=False,
+    ):
         """Get file for current exchange_record in the given destination state.
 
         :param state: string ("pending", "done", "error")
         :param filename: custom file name, exchange_record filename used by default
+        :param raise_if_missing: when True, storage errors are re-raised as
+            swallable exceptions so the caller transitions the record to an
+            error state instead of treating "no content" as a successful read.
         :return: remote file content as string
         """
         path = self._get_remote_file_path(exchange_record, state, filename=filename)
@@ -84,14 +97,25 @@ class EdiOcaStorageHandler(models.AbstractModel):
                 path,
                 state,
             )
+            if raise_if_missing:
+                raise
             return None
-        except OSError:
-            _logger.info(
-                "Ignored OSError when trying to get file %s into path %s for state %s",
+        except OSError as err:
+            _logger.warning(
+                "OSError when trying to get file %s into path %s for state %s: %s",
                 filename,
                 path,
                 state,
+                err,
             )
+            if raise_if_missing:
+                raise UserError(
+                    self.env._(
+                        "Storage error while reading %(path)s: %(error)s",
+                        path=path.as_posix(),
+                        error=str(err),
+                    )
+                ) from err
             return None
 
     def check(self, exchange_record):


### PR DESCRIPTION
When the FTP read fails on receive (connection drop, missing file), the exchange record was wrongly transitioning to "input_received" with an empty file, because "_get_remote_file"" was silently swallowing the error and returning None. Fixed by raising on receive instead, so the record correctly goes to "input_receive_error".

As a side effect, since the record sat in "input_received" with no file, every run of the processing cron tried to process it, failed because the file was missing, and queued a new job. This led to an ever-growing pile of failing queue  jobs for the same record.

<img width="1232" height="456" alt="image" src="https://github.com/user-attachments/assets/7710aa5b-61f4-4496-893b-230a67f8b4ec" />




