### PR TITLE
[FIX] edi_core_oca: use savepoint to prevent state corruption on errors

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -144,7 +144,8 @@ class EDIBackend(models.Model):
         if output:
             message = exchange_record._exchange_status_message("generate_ok")
             try:
-                self._validate_data(exchange_record, output)
+                with self.env.cr.savepoint():
+                    self._validate_data(exchange_record, output)
             except EDIValidationError as err:
                 traceback = _get_exception_traceback()
                 error = _get_exception_msg(err)
@@ -240,8 +241,9 @@ class EDIBackend(models.Model):
         message = None
         res = ""
         try:
-            self._exchange_send(exchange_record)
-            _logger.debug("%s sent", exchange_record.identifier)
+            with self.env.cr.savepoint():
+                self._exchange_send(exchange_record)
+                _logger.debug("%s sent", exchange_record.identifier)
         except self._send_retryable_exceptions() as err:
             traceback = _get_exception_traceback()
             error = _get_exception_msg(err)
@@ -469,7 +471,8 @@ class EDIBackend(models.Model):
         message = None
         res = None
         try:
-            res = self._exchange_process(exchange_record)
+            with self.env.cr.savepoint():
+                res = self._exchange_process(exchange_record)
         except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_process_break_on_error"):
                 raise
@@ -526,11 +529,12 @@ class EDIBackend(models.Model):
         message = None
         res = None
         try:
-            content = self._exchange_receive(exchange_record)
-            # Ignore result of FileNotFoundError/OSError
-            if content is not None:
-                exchange_record._set_file_content(content)
-                self._validate_data(exchange_record)
+            with self.env.cr.savepoint():
+                content = self._exchange_receive(exchange_record)
+                # Ignore result of FileNotFoundError/OSError
+                if content is not None:
+                    exchange_record._set_file_content(content)
+                    self._validate_data(exchange_record)
         except EDIValidationError as err:
             traceback = _get_exception_traceback()
             error = _get_exception_msg(err)

--- a/edi_core_oca/tests/fake_models.py
+++ b/edi_core_oca/tests/fake_models.py
@@ -14,6 +14,7 @@ class EdiExchangeConsumerTest(models.Model):
     _description = "Model used only for test"
 
     name = fields.Char()
+    ref = fields.Char()
     edi_config_ids = fields.Many2many(
         string="EDI Test Config Ids",
         comodel_name="edi.configuration",


### PR DESCRIPTION
Some errors such as

```
  ValueError,
  FileNotFoundError,
  exceptions.UserError,
  exceptions.ValidationError,
```

are caught, never re-raised, and the transaction is finally committed.

Which means a UserError/ValidationError gets committed, leading to corruption of the processed data.