### PR TITLE
[19.0][FIX] edi_endpoint_oca: fix context must be a dict

### DIFF
--- a/edi_endpoint_oca/models/edi_endpoint.py
+++ b/edi_endpoint_oca/models/edi_endpoint.py
@@ -106,7 +106,7 @@ class EDIEndpoint(models.Model):
         # Purge default search filters from ctx to avoid hiding records
         ctx = action.get("context", {})
         if isinstance(ctx, str):
-            ctx = safe_eval.safe_eval(ctx, self.env.context)
+            ctx = safe_eval.safe_eval(ctx, dict(self.env.context))
         action["context"] = {
             k: v for k, v in ctx.items() if not k.startswith("search_default_")
         }


### PR DESCRIPTION
When clicking on Exchanges from EDI Endpoints, an Assertion Error is raised. self.env.context is a frozendict, so converting it to dict in safe_eval:

From runboat standard 19.0:
<img width="1896" height="896" alt="image" src="https://github.com/user-attachments/assets/aed39211-2032-4295-bcc6-8725d17c64a5" />
