### PR TITLE
[16.0] [FIX] edi_oca: search with slice only can be count=False

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -629,7 +629,7 @@ class EDIExchangeRecord(models.Model):
                     offset=offset + len(orig_ids),
                     limit=limit,
                     order=order,
-                    count=count,
+                    count=False,
                     access_rights_uid=access_rights_uid,
                 )[: limit - len(result)]
             )


### PR DESCRIPTION
If we want to slice the search method result, it must always be a list, not an integer, which is what the search method returns when count=True. Sometimes count=True is propagated and when the workflow reaches this point, it raises an exception like this:

```
File "/opt/odoo/auto/addons/edi_oca/models/edi_exchange_record.py", line 627, in _search
self._search(
TypeError: 'int' object is not subscriptable
```