### PR TITLE
[18.0][BACKPORT] edi_core_oca: fire on_edi_exchange_error for all error states

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -121,6 +121,7 @@ class EDIBackend(models.Model):
         :param kw: keyword args to be propagated to output generate handler
         """
         self.ensure_one()
+        old_state = exchange_record.edi_exchange_state
         if force and exchange_record.exchange_file:
             # Remove file to regenerate
             exchange_record.exchange_file = False
@@ -148,7 +149,6 @@ class EDIBackend(models.Model):
                 traceback = _get_exception_traceback()
                 error = _get_exception_msg(err)
                 state = "validate_error"
-                message = exchange_record._exchange_status_message("validate_ko")
                 exchange_record.update(
                     {
                         "edi_exchange_state": state,
@@ -156,6 +156,15 @@ class EDIBackend(models.Model):
                         "exchange_error_traceback": traceback,
                     }
                 )
+                if old_state != state:
+                    exchange_record._notify_error("validate_ko")
+                # At this point `message` still holds the "generate_ok" success
+                # text set before validation ran. Generation succeeded but
+                # validation failed, so clear it: `_notify_error` has already
+                # posted the validation error (and fired the error event), and
+                # we must not let `notify_action_complete` below post the stale
+                # success message on top of it.
+                message = None
         exchange_record.notify_action_complete("generate", message=message)
         return message
 
@@ -226,7 +235,7 @@ class EDIBackend(models.Model):
         check = self._output_check_send(exchange_record)
         if not check:
             return self._failed_output_check_send_msg()
-        state = exchange_record.edi_exchange_state
+        old_state = state = exchange_record.edi_exchange_state
         error = traceback = False
         message = None
         res = ""
@@ -246,7 +255,6 @@ class EDIBackend(models.Model):
             traceback = _get_exception_traceback()
             error = _get_exception_msg(err)
             state = "output_error_on_send"
-            message = exchange_record._exchange_status_message("send_ko")
             res = f"Error: {error}"
             _logger.debug(
                 "%s send failed. Marked as errored.", exchange_record.identifier
@@ -279,6 +287,8 @@ class EDIBackend(models.Model):
                         "exchanged_on": fields.Datetime.now(),
                     }
                 )
+                if old_state != state and state == "output_error_on_send":
+                    exchange_record._notify_error("send_ko")
         exchange_record.notify_action_complete("send", message=message)
         return res
 
@@ -511,7 +521,7 @@ class EDIBackend(models.Model):
         check = self._exchange_receive_check(exchange_record)
         if not check:
             return "Nothing to do. Likely already received."
-        state = exchange_record.edi_exchange_state
+        old_state = state = exchange_record.edi_exchange_state
         error = traceback = False
         message = None
         content = None
@@ -525,7 +535,6 @@ class EDIBackend(models.Model):
             traceback = _get_exception_traceback()
             error = _get_exception_msg(err)
             state = "validate_error"
-            message = exchange_record._exchange_status_message("validate_ko")
             res = f"Validation error: {error}"
         except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_receive_break_on_error"):
@@ -533,7 +542,6 @@ class EDIBackend(models.Model):
             traceback = _get_exception_traceback()
             error = _get_exception_msg(err)
             state = "input_receive_error"
-            message = exchange_record._exchange_status_message("receive_ko")
             res = f"Input error: {error}"
         except (OperationalError, IntegrityError):
             # We don't want the finally block to be executed in this case as
@@ -558,6 +566,10 @@ class EDIBackend(models.Model):
                         "exchanged_on": fields.Datetime.now(),
                     }
                 )
+                if old_state != state and state == "input_receive_error":
+                    exchange_record._notify_error("receive_ko")
+                if old_state != state and state == "validate_error":
+                    exchange_record._notify_error("validate_ko")
         exchange_record.notify_action_complete("receive", message=message)
         return res
 

--- a/edi_core_oca/tests/common.py
+++ b/edi_core_oca/tests/common.py
@@ -86,3 +86,26 @@ class EDIBackendCommonTestCase(TransactionCase, EDIBackendTestMixin):
         super().setUpClass()
         cls._setup_env()
         cls._setup_records()
+
+    def _make_global_error_conf(self, exchange_type):
+        """Register a global ``edi.configuration`` bound to the
+        ``on_edi_exchange_error`` event.
+
+        Its snippet writes a marker on the configuration so a test can assert
+        the error event actually fired. This is the observable behaviour that
+        distinguishes an errored exchange (which must notify, e.g. create the
+        activities handled by ``edi_notification_oca``) from one that merely
+        posts a chatter message via ``notify_action_complete``.
+        """
+        trigger = self.env.ref("edi_core_oca.edi_config_trigger_record_error")
+        return self.env["edi.configuration"].create(
+            {
+                "name": "Test notify on error",
+                "active": True,
+                "backend_id": self.backend.id,
+                "type_id": exchange_type.id,
+                "trigger_id": trigger.id,
+                "is_global": True,
+                "snippet_do": "conf.write({'description': 'error-event-fired'})",
+            }
+        )

--- a/edi_core_oca/tests/test_backend_input.py
+++ b/edi_core_oca/tests/test_backend_input.py
@@ -70,6 +70,16 @@ class EDIBackendTestInputCase(EDIBackendCommonTestCase):
             self.record, [{"edi_exchange_state": "input_receive_error"}]
         )
 
+    def test_receive_no_allow_empty_file_triggers_notify_error(self):
+        self.record.edi_exchange_state = "input_pending"
+        conf = self._make_global_error_conf(self.record.type_id)
+        self.backend.with_context(
+            fake_output="", _edi_receive_break_on_error=False
+        ).exchange_receive(self.record)
+        # The error event must fire so downstream notifications (e.g.
+        # edi_notification_oca activities) are triggered.
+        self.assertEqual(conf.description, "error-event-fired")
+
     def test_receive_allow_empty_file_record(self):
         self.record.edi_exchange_state = "input_pending"
         self.record.type_id.allow_empty_files_on_receive = True

--- a/edi_core_oca/tests/test_backend_output.py
+++ b/edi_core_oca/tests/test_backend_output.py
@@ -93,6 +93,17 @@ class EDIBackendTestOutputCase(EDIBackendCommonTestCase):
             "OOPS! Something went wrong :(", self.record.exchange_error_traceback
         )
 
+    def test_send_record_with_error_triggers_notify_error(self):
+        self.record.write({"edi_exchange_state": "output_pending"})
+        self.record._set_file_content(f"TEST {self.record.id}")
+        conf = self._make_global_error_conf(self.record.type_id)
+        self.record.with_context(
+            test_break_send="OOPS! Something went wrong :("
+        ).action_exchange_send()
+        # The error event must fire so downstream notifications (e.g.
+        # edi_notification_oca activities) are triggered.
+        self.assertEqual(conf.description, "error-event-fired")
+
     def test_send_invalid_direction(self):
         vals = {
             "model": self.partner._name,

--- a/edi_core_oca/tests/test_backend_validate.py
+++ b/edi_core_oca/tests/test_backend_validate.py
@@ -79,6 +79,17 @@ class EDIBackendTestValidateCase(EDIBackendCommonTestCase):
         )
         self.assertIn("Data seems wrong!", self.record_in.exchange_error_traceback)
 
+    def test_receive_validate_record_error_triggers_notify_error(self):
+        self.record_in.write({"edi_exchange_state": "input_pending"})
+        exc = EDIValidationError("Data seems wrong!")
+        conf = self._make_global_error_conf(self.record_in.type_id)
+        self.backend.with_context(test_break_input_validate=exc).exchange_receive(
+            self.record_in
+        )
+        # The error event must fire so downstream notifications (e.g.
+        # edi_notification_oca activities) are triggered.
+        self.assertEqual(conf.description, "error-event-fired")
+
     def test_generate_validate_record(self):
         self.record_out.write({"edi_exchange_state": "new"})
         self.backend.exchange_generate(self.record_out)
@@ -112,6 +123,17 @@ class EDIBackendTestValidateCase(EDIBackendCommonTestCase):
             ],
         )
         self.assertIn("Data seems wrong!", self.record_out.exchange_error_traceback)
+
+    def test_generate_validate_record_error_triggers_notify_error(self):
+        self.record_out.write({"edi_exchange_state": "new"})
+        exc = EDIValidationError("Data seems wrong!")
+        conf = self._make_global_error_conf(self.record_out.type_id)
+        self.backend.with_context(test_break_output_validate=exc).exchange_generate(
+            self.record_out
+        )
+        # The error event must fire so downstream notifications (e.g.
+        # edi_notification_oca activities) are triggered.
+        self.assertEqual(conf.description, "error-event-fired")
 
     def test_validate_record_error_regenerate(self):
         self.record_out.write({"edi_exchange_state": "new"})


### PR DESCRIPTION
Backport of https://github.com/OCA/edi-framework/pull/298