### PR TITLE
[18.0][IMP] edi_core_oca: Auto cancel exchange records that cannot be sent

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -62,6 +62,9 @@ class EDIBackend(models.Model):
     Usecase: the web service you send the file to processes it on the fly.
     """
     )
+    output_cancel_cannot_send_auto = fields.Boolean(
+        string="Automatically cancel the records that cannot be sent"
+    )
     active = fields.Boolean(default=True)
     company_id = fields.Many2one("res.company", string="Company")
     auto_archive_records_after_days = fields.Integer(
@@ -225,7 +228,11 @@ class EDIBackend(models.Model):
         # In case already sent: skip sending and check the state
         check = self._output_check_send(exchange_record)
         if not check:
-            return self._failed_output_check_send_msg()
+            message = self._failed_output_check_send_msg(exchange_record=exchange_record)
+            if self.output_cancel_cannot_send_auto:
+                exchange_record.edi_exchange_state = "output_cancel"
+                exchange_record._notify_cancel(message)
+            return message
         state = exchange_record.edi_exchange_state
         error = traceback = False
         message = None
@@ -675,7 +682,7 @@ class EDIBackend(models.Model):
                 raise
             return False
 
-    def _failed_output_check_send_msg(self):
+    def _failed_output_check_send_msg(self, exchange_record=None):
         return "Nothing to do. Likely already sent."
 
     def _get_exec_handler(self, exchange_record, action):

--- a/edi_core_oca/models/edi_exchange_record.py
+++ b/edi_core_oca/models/edi_exchange_record.py
@@ -97,6 +97,7 @@ class EDIExchangeRecord(models.Model):
             ("output_sent", "Sent"),
             ("output_sent_and_processed", "Sent and processed"),
             ("output_sent_and_error", "Sent and error"),
+            ("output_cancel", "Sending canceled"),
             # input exchange states
             ("input_pending", "Waiting to be received"),
             ("input_received", "Received"),
@@ -423,6 +424,7 @@ class EDIExchangeRecord(models.Model):
             ),
             "ack_received_error": self.env._("ACK file received but contains errors."),
             "validate_ko": self.env._("Exchange not valid"),
+            "cancel": self.env._("Exchange canceled"),
         }
 
     def _exchange_status_message(self, key):
@@ -557,6 +559,12 @@ class EDIExchangeRecord(models.Model):
             level="error",
         )
         self._trigger_edi_event("error")
+
+    def _notify_cancel(self, message=None):
+        if message is None:
+            message = self._exchange_status_message("cancel")
+        self._notify_related_record(message)
+        self._trigger_edi_event("cancel")
 
     def _notify_ack_received(self):
         self._notify_related_record(self._exchange_status_message("ack_received"))

--- a/edi_core_oca/tests/test_backend_output.py
+++ b/edi_core_oca/tests/test_backend_output.py
@@ -133,3 +133,11 @@ class EDIBackendTestOutputCase(EDIBackendCommonTestCase):
             ).exchange_send(self.record)
         self.assertRecordValues(self.record, [{"edi_exchange_state": "output_pending"}])
         self.assertFalse(self.record.exchange_error)
+
+    def test_send_auto_cancel(self):
+        self.backend.write({"output_cancel_cannot_send_auto": True})
+        self.record.write({"edi_exchange_state": "output_pending"})
+        with mock.patch.object(type(self.backend), "_output_check_send") as mocked:
+            mocked.return_value = False
+            self.backend.exchange_send(self.record)
+            self.assertRecordValues(self.record, [{"edi_exchange_state": "output_cancel"}])

--- a/edi_core_oca/views/edi_backend_views.xml
+++ b/edi_core_oca/views/edi_backend_views.xml
@@ -53,6 +53,7 @@
                         <!-- can be used to hide elements based on the backend type, e.g. notebook pages -->
                         <field name="backend_type_code" invisible="1" />
                         <field name="output_sent_processed_auto" />
+                        <field name="output_cancel_cannot_send_auto" />
                         <field name="active" invisible="1" />
                         <field name="company_id" groups="base.group_multi_company" />
                     </group>


### PR DESCRIPTION
This allows to set outgoing exchange records as canceled in case they cannot be sent by customizing edi.backend._output_check_send.