### PR TITLE
[19.0][IMP] edi_core_oca: expose env in code snippet eval context

### DIFF
--- a/edi_core_oca/models/edi_configuration.py
+++ b/edi_core_oca/models/edi_configuration.py
@@ -138,6 +138,7 @@ class EdiConfiguration(models.Model):
         :returns: dict -- evaluation context given to safe_eval
         """
         ctx = {
+            "env": self.env,
             "uid": self.env.uid,
             "user": self.env.user,
             "DotDict": DotDict,


### PR DESCRIPTION
Make `env` directly available in `edi.configuration` snippets, alongside
the existing `record`, `conf`, `user` and `uid` helpers. Snippets no
longer need to reach for `record.env` to access the environment, which
keeps them shorter and consistent with the context shared via
`env.context`.