### PR TITLE
[18.0][BACKPORT] edi_core_oca: expose env in code snippet eval context

### DIFF
--- a/edi_core_oca/models/edi_configuration.py
+++ b/edi_core_oca/models/edi_configuration.py
@@ -139,6 +139,7 @@ class EdiConfiguration(models.Model):
         :returns: dict -- evaluation context given to safe_eval
         """
         ctx = {
+            "env": self.env,
             "uid": self.env.uid,
             "user": self.env.user,
             "DotDict": DotDict,


### PR DESCRIPTION
Backport from https://github.com/OCA/edi-framework/pull/302