### PR TITLE
[19.0][IMP] edi_exchange_deduplicate_oca:  add configurable deduplication states

### DIFF
--- a/edi_exchange_deduplicate_oca/README.rst
+++ b/edi_exchange_deduplicate_oca/README.rst
@@ -62,6 +62,9 @@ the same record. If so, mark the oldest one as obsolete (except
 
 - "block_obsolescence" is an technical option on records to avoid
   marking them as obsolete.
+- You can restrict deduplication to specific exchange states with the
+  technical field "deduplicate_on_exchange_record_status"
+  (comma-separated values from "edi_exchange_state").
 
 With all the types that have been enabled "Delete obsolete records"
 option, the cron will remove their obsolete records.
@@ -92,6 +95,7 @@ Contributors
 
 - Simone Orsi <simone.orsi@camptocamp.com>
 - Duong (Tran Quoc) <duongtq@trobz.com>
+- Hadrien Huvelle <hadrien.huvelle@camptocamp.com>
 
 Maintainers
 -----------

--- a/edi_exchange_deduplicate_oca/models/edi_exchange_record.py
+++ b/edi_exchange_deduplicate_oca/models/edi_exchange_record.py
@@ -40,6 +40,9 @@ class EDIExchangeRecord(models.Model):
 
     def _edi_get_duplicates(self, count=False):
         self.ensure_one()
+        edi_exchange_state_to_check = list(
+            self.type_id._deduplicate_get_exchange_record_states()
+        )
         return (self.search_count if count else self.search)(
             Domain(
                 [
@@ -47,7 +50,7 @@ class EDIExchangeRecord(models.Model):
                     ("res_id", "=", self.res_id),
                     ("model", "=", self.model),
                     ("type_id", "=", self.type_id.id),
-                    ("edi_exchange_state", "in", ("new", "output_pending")),
+                    ("edi_exchange_state", "in", edi_exchange_state_to_check),
                     ("block_obsolescence", "=", False),
                 ],
             )

--- a/edi_exchange_deduplicate_oca/models/edi_exchange_type.py
+++ b/edi_exchange_deduplicate_oca/models/edi_exchange_type.py
@@ -1,7 +1,8 @@
 # Copyright 2024 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class EDIExchangeType(models.Model):
@@ -18,3 +19,35 @@ class EDIExchangeType(models.Model):
         default=True,
         help="Delete records marked as obsolete.",
     )
+
+    deduplicate_on_exchange_record_status = fields.Char(
+        default="new,output_pending",
+        groups="base.group_no_one",
+    )
+
+    def _deduplicate_get_exchange_record_states(self):
+        self.ensure_one()
+        return {
+            state.strip()
+            for state in (self.deduplicate_on_exchange_record_status or "").split(",")
+            if state.strip()
+        }
+
+    @api.constrains("deduplicate_on_exchange_record_status")
+    def _check_deduplicate_on_exchange_record_status(self):
+        exchange_state_field = self.env["edi.exchange.record"]._fields[
+            "edi_exchange_state"
+        ]
+        allowed_states = set(exchange_state_field.get_values(self.env))
+        for rec in self:
+            configured_states = rec._deduplicate_get_exchange_record_states()
+            invalid_states = sorted(configured_states - allowed_states)
+            if invalid_states:
+                raise ValidationError(
+                    self.env._(
+                        "Invalid exchange state(s): %(invalid_states)s. "
+                        "Allowed values are: %(allowed_states)s",
+                        invalid_states=", ".join(invalid_states),
+                        allowed_states=", ".join(sorted(allowed_states)),
+                    )
+                )

--- a/edi_exchange_deduplicate_oca/readme/CONTRIBUTORS.md
+++ b/edi_exchange_deduplicate_oca/readme/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 - Simone Orsi \<simone.orsi@camptocamp.com\>
 - Duong (Tran Quoc) \<duongtq@trobz.com\>
+- Hadrien Huvelle \<hadrien.huvelle@camptocamp.com\>

--- a/edi_exchange_deduplicate_oca/readme/USAGE.md
+++ b/edi_exchange_deduplicate_oca/readme/USAGE.md
@@ -1,6 +1,7 @@
 With all the types that have been enabled "Deduplicate on Send" option, this module will check their records if a fresher one does not exist for the same record. If so, mark the oldest one as obsolete (except "block_obsolescence" records)  
 - "block_obsolescence" is an technical option on records to avoid
   marking them as obsolete.
+- You can restrict deduplication to specific exchange states with the technical field "deduplicate_on_exchange_record_status" (comma-separated values from "edi_exchange_state").
 
 With all the types that have been enabled "Delete obsolete records" option, the cron will remove their obsolete records.  
 - If the records are obsolete, delete them even if their type's flag has

--- a/edi_exchange_deduplicate_oca/static/description/index.html
+++ b/edi_exchange_deduplicate_oca/static/description/index.html
@@ -411,6 +411,9 @@ the same record. If so, mark the oldest one as obsolete (except
 <ul class="simple">
 <li>“block_obsolescence” is an technical option on records to avoid
 marking them as obsolete.</li>
+<li>You can restrict deduplication to specific exchange states with the
+technical field “deduplicate_on_exchange_record_status”
+(comma-separated values from “edi_exchange_state”).</li>
 </ul>
 <p>With all the types that have been enabled “Delete obsolete records”
 option, the cron will remove their obsolete records.</p>
@@ -440,6 +443,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Simone Orsi &lt;<a class="reference external" href="mailto:simone.orsi&#64;camptocamp.com">simone.orsi&#64;camptocamp.com</a>&gt;</li>
 <li>Duong (Tran Quoc) &lt;<a class="reference external" href="mailto:duongtq&#64;trobz.com">duongtq&#64;trobz.com</a>&gt;</li>
+<li>Hadrien Huvelle &lt;<a class="reference external" href="mailto:hadrien.huvelle&#64;camptocamp.com">hadrien.huvelle&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/edi_exchange_deduplicate_oca/tests/__init__.py
+++ b/edi_exchange_deduplicate_oca/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_edi_backend_cron
+from . import test_deduplicate_on_exchange_record_status
 from . import test_edi_duplicate

--- a/edi_exchange_deduplicate_oca/tests/test_deduplicate_on_exchange_record_status.py
+++ b/edi_exchange_deduplicate_oca/tests/test_deduplicate_on_exchange_record_status.py
@@ -1,0 +1,98 @@
+# Copyright 2024 Camptocamp
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tools import mute_logger
+
+from .test_edi_duplicate import EDIDeduplicateTestCase
+
+LOGGERS = (
+    "odoo.addons.edi_core_oca.models.edi_backend",
+    "odoo.addons.queue_job.delay",
+)
+
+
+class TestDeduplicateOnExchangeRecordStatus(EDIDeduplicateTestCase):
+    def test_configured_statuses_must_exist_in_selection(self):
+        with self.assertRaisesRegex(ValidationError, "Invalid exchange state"):
+            self.exchange_type_out.write(
+                {
+                    "deduplicate_on_exchange_record_status": "new,not_a_state",
+                }
+            )
+
+    def test_configured_statuses_accept_valid_values(self):
+        # "obsolete" comes from this addon via selection_add on edi_exchange_state.
+        self.exchange_type_out.write(
+            {
+                "deduplicate_on_exchange_record_status": (
+                    "new, output_pending, obsolete"
+                ),
+            }
+        )
+        self.assertEqual(
+            self.exchange_type_out.deduplicate_on_exchange_record_status,
+            "new, output_pending, obsolete",
+        )
+
+    @mute_logger(*LOGGERS)
+    def test_default_status_deduplicates_new_records(self):
+        self.exchange_type_out.write(
+            {
+                "deduplicate_on_send": True,
+            }
+        )
+        record1 = self.backend.create_record(
+            "test_csv_output",
+            {
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+        self.backend.create_record(
+            "test_csv_output",
+            {
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+
+        self.assertEqual(record1.edi_exchange_state, "obsolete")
+
+    @mute_logger(*LOGGERS)
+    def test_custom_status_filter_is_used_for_deduplication(self):
+        self.exchange_type_out.write(
+            {
+                "deduplicate_on_send": True,
+                "deduplicate_on_exchange_record_status": "output_pending",
+            }
+        )
+        record1 = self.backend.create_record(
+            "test_csv_output",
+            {
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+        record2 = self.backend.create_record(
+            "test_csv_output",
+            {
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+
+        # "new" is not part of the configured list, so no deduplication yet.
+        self.assertEqual(record1.edi_exchange_state, "new")
+
+        record1.edi_exchange_state = "output_pending"
+        self.backend.create_record(
+            "test_csv_output",
+            {
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+
+        self.assertEqual(record1.edi_exchange_state, "obsolete")
+        self.assertEqual(record2.edi_exchange_state, "new")


### PR DESCRIPTION
Implement deduplicate_on_exchange_record_status on Exchange Record type setting that allows you to set what states should trigger the obsolescence of an exchange record