### PR TITLE
[FIX] edi_core_oca: fix tests

### DIFF
--- a/edi_core_oca/tests/test_backend_base.py
+++ b/edi_core_oca/tests/test_backend_base.py
@@ -51,7 +51,7 @@ class EDIBackendTestCaseBase(EDIBackendCommonTestCase):
         expected = {
             "type_id": self.exchange_type_in.id,
             "edi_exchange_state": "new",
-            "exchange_filename": "EDI_EXC_TEST-test_csv_input-2020-10-21-100000.csv",
+            "exchange_filename": "EDI_EXC_TEST-test_csv_input-2020-10-21-10-00-00.csv",
         }
         self.assertRecordValues(record, [expected])
         self.assertEqual(record.record, self.partner)

--- a/edi_core_oca/tests/test_exchange_type.py
+++ b/edi_core_oca/tests/test_exchange_type.py
@@ -111,11 +111,11 @@ class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
         # Test with datetime in filename pattern
         self.exchange_type_out.exchange_file_ext = "csv"
         self.exchange_type_out.exchange_filename_pattern = "Test-File-{dt}"
-        self._test_exchange_filename("Test-File-2022-04-28-083724.csv")
+        self._test_exchange_filename("Test-File-2022-04-28-08-37-24.csv")
 
         # Add timezone on current user
         self.env.user.tz = "America/New_York"  # New_York time is -4h
-        self._test_exchange_filename("Test-File-2022-04-28-043724.csv")
+        self._test_exchange_filename("Test-File-2022-04-28-04-37-24.csv")
 
         # Force date pattern on advanced settings
         self.exchange_type_out.advanced_settings_edit = """
@@ -130,7 +130,7 @@ class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
             # Rome time is +2h
             force_tz: Europe/Rome
         """
-        self._test_exchange_filename("Test-File-2022-04-28-103724.csv")
+        self._test_exchange_filename("Test-File-2022-04-28-10-37-24.csv")
 
         # Force date pattern and timezone on advanced settings
         self.exchange_type_out.advanced_settings_edit = """


### PR DESCRIPTION
An error happens due to this change.

https://github.com/odoo/odoo/commit/6fd3703fde9d81da69cb6fad999644204f517a56

Now, `:` is transform into `-`