### PR TITLE
[18.0][FIX] edi_core_oca: wrong var init on exchange_receive

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -514,7 +514,7 @@ class EDIBackend(models.Model):
         state = exchange_record.edi_exchange_state
         error = traceback = False
         message = None
-        content = None
+        res = None
         try:
             content = self._exchange_receive(exchange_record)
             # Ignore result of FileNotFoundError/OSError


### PR DESCRIPTION
(cherry picked from commit dc710300141fc16ba85edb83b17112c09ef777cb)
Backport of https://github.com/OCA/edi-framework/pull/310