### PR TITLE
[19.0][IMP] edi_queue_oca: add timezone-aware daily ETA scheduling

### DIFF
--- a/edi_queue_oca/README.rst
+++ b/edi_queue_oca/README.rst
@@ -32,21 +32,94 @@ Edi Queue Oca
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module integrates EDI with Queue Job and now the edi exchange
-records are generated using queue.
+This module integrates EDI exchange records with `Queue
+Job <https://github.com/OCA/queue>`__, so that the four core exchange
+actions — **generate**, **send**, **receive**, and **process** — are
+dispatched as background jobs instead of running synchronously.
 
-No need of doing a configuration on it, however, we can specify priority
-and channel in exchange type.
-
-Exchange types can also define a daily execution time with ``eta_time``.
-The value is entered as a ``float_time`` in the current user's timezone
-(``22.5`` means 22:30 local time) and is converted at runtime to the
-next matching UTC datetime used as the queue job ETA.
+Each exchange type can optionally route its jobs to a specific channel,
+set a priority, or **hold all jobs until a fixed time of day** — useful
+when a trading partner's receiving system has a nightly processing
+window or when the operator wants to concentrate resource-intensive EDI
+work in off-peak hours.
 
 **Table of contents**
 
 .. contents::
    :local:
+
+Usage
+=====
+
+Automatic job dispatch
+----------------------
+
+All exchange actions on ``edi.exchange.record`` are dispatched as
+background jobs automatically. No per-record configuration is required;
+the integration is active for every exchange type as soon as the module
+is installed.
+
+Per-type job configuration
+--------------------------
+
+Each **Exchange Type** gains a *Queue* tab with optional settings:
+
++---------------------------+------------------------------------------+
+| Field                     | Purpose                                  |
++===========================+==========================================+
+| **Job channel**           | Route jobs to a specific channel (e.g.   |
+|                           | ``root.edi.high``).                      |
++---------------------------+------------------------------------------+
+| **Job priority**          | Integer priority passed to the queue job |
+|                           | (lower = higher priority).               |
++---------------------------+------------------------------------------+
+| **Enable ETA Scheduling** | Toggle to activate daily job             |
+|                           | accumulation (see below).                |
++---------------------------+------------------------------------------+
+| **Execution time**        | Hour, minute, and timezone at which      |
+|                           | accumulated jobs are released. Visible   |
+|                           | only when ETA Scheduling is enabled.     |
++---------------------------+------------------------------------------+
+
+Accumulating jobs until a fixed daily time
+------------------------------------------
+
+Enabling **ETA Scheduling** on an exchange type causes every job created
+for that type to be **held in the queue** until the configured time of
+day, rather than being processed immediately. All jobs that arrive
+during the day accumulate and are released together at that moment.
+
+**Typical use cases:**
+
+- A trading partner's receiving system only processes incoming files at
+  a specific nightly window (e.g. 22:00).
+- Resource-intensive EDI operations (large exports, heavy
+  transformations) should be deferred to off-peak hours to avoid
+  competing with daytime workloads.
+- Operational preference to send a batch of documents at a predictable
+  daily time instead of dispatching them one by one in real time.
+
+The execution time is configured with three fields:
+
+- **Hour** — hour of the day (00–23).
+- **Minute** — minute of the hour (00–59).
+- **Timezone** — the timezone in which the hour and minute are
+  interpreted. Defaults to the current user's timezone.
+
+At runtime the configured time is converted to the next matching UTC
+datetime and set as the queue job ETA. If the target time for today has
+already passed, the job is automatically scheduled for the same time
+tomorrow.
+
+When **Enable ETA Scheduling** is off, jobs are dispatched immediately
+as usual.
+
+Duplicate-job prevention
+------------------------
+
+An identity key is attached to every queued job, so re-triggering an
+action for a record that already has a pending job does not enqueue a
+duplicate.
 
 Bug Tracker
 ===========

--- a/edi_queue_oca/README.rst
+++ b/edi_queue_oca/README.rst
@@ -38,6 +38,11 @@ records are generated using queue.
 No need of doing a configuration on it, however, we can specify priority
 and channel in exchange type.
 
+Exchange types can also define a daily execution time with ``eta_time``.
+The value is entered as a ``float_time`` in the current user's timezone
+(``22.5`` means 22:30 local time) and is converted at runtime to the
+next matching UTC datetime used as the queue job ETA.
+
 **Table of contents**
 
 .. contents::

--- a/edi_queue_oca/models/edi_exchange_record.py
+++ b/edi_queue_oca/models/edi_exchange_record.py
@@ -47,6 +47,8 @@ class EdiExchangeRecord(models.Model):
         priority = exchange_type.job_priority
         if priority:
             params["priority"] = priority
+        if exchange_type.job_eta_enabled and (eta := exchange_type._get_job_eta()):
+            params["eta"] = eta
         # Avoid generating the same job for the same record if existing
         params["identity_key"] = exchange_record_job_identity_exact
         return params

--- a/edi_queue_oca/models/edi_exchange_type.py
+++ b/edi_queue_oca/models/edi_exchange_type.py
@@ -2,7 +2,14 @@
 # Copyright 2025 Dixmit
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models
+from datetime import datetime
+
+import pytz
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models
+
+from odoo.addons.base.models.res_partner import _tz_get as timezone_selection
 
 
 class EdiExchangeType(models.Model):
@@ -12,3 +19,64 @@ class EdiExchangeType(models.Model):
         comodel_name="queue.job.channel",
     )
     job_priority = fields.Integer()
+    job_eta_enabled = fields.Boolean(
+        string="Enable ETA Scheduling",
+        help="Accumulate all queue jobs for this exchange type and release them "
+        "at the daily time configured below, instead of dispatching each job "
+        "immediately. Use this when a trading partner only processes files at a "
+        "fixed daily window, or to concentrate resource-intensive EDI work in "
+        "off-peak hours.",
+    )
+    job_eta_hour = fields.Selection(
+        [(str(x).zfill(2), str(x).zfill(2)) for x in range(24)],
+        string="Execution time - hour",
+        help="Hour of the day at which jobs for this type should be scheduled.",
+        default="00",
+    )
+    job_eta_minute = fields.Selection(
+        [(str(x).zfill(2), str(x).zfill(2)) for x in range(60)],
+        string="Execution time - minute",
+        help="Minute of the hour at which jobs for this type should be scheduled.",
+        default="00",
+    )
+    job_eta_tz = fields.Selection(
+        timezone_selection,
+        string="Execution time - timezone",
+        help="ETA's timezone for jobs of this type",
+        default=lambda self: self._get_default_eta_tz(),
+    )
+
+    @api.model
+    def _get_default_eta_tz(self):
+        tz_list = timezone_selection(self)
+        return self.env.user.tz or (tz_list and tz_list[0][0]) or "UTC"
+
+    def _get_job_eta(self):
+        """Returns the ETA for the current type as timezone-naive datetime"""
+        self.ensure_one()
+        if (
+            not self.job_eta_enabled
+            or not self.job_eta_tz
+            or not self.job_eta_hour
+            or not self.job_eta_minute
+        ):
+            return None
+
+        self.ensure_one()
+        now = pytz.UTC.localize(datetime.utcnow())
+        eta = (
+            pytz.timezone(self.job_eta_tz)
+            .localize(
+                datetime(
+                    now.year,
+                    now.month,
+                    now.day,
+                    int(self.job_eta_hour),
+                    int(self.job_eta_minute),
+                )
+            )
+            .astimezone(pytz.UTC)
+        )
+        if eta < now:
+            eta += relativedelta(days=1)
+        return eta.replace(tzinfo=None)

--- a/edi_queue_oca/readme/DESCRIPTION.md
+++ b/edi_queue_oca/readme/DESCRIPTION.md
@@ -1,8 +1,9 @@
-This module integrates EDI with Queue Job and now the edi exchange records are generated using queue.
+This module integrates EDI exchange records with
+[Queue Job](https://github.com/OCA/queue), so that the four core exchange
+actions — **generate**, **send**, **receive**, and **process** — are dispatched
+as background jobs instead of running synchronously.
 
-No need of doing a configuration on it, however, we can specify priority and channel in exchange type.
-
-Exchange types can also define a daily execution time with `eta_time`.
-The value is entered as a `float_time` in the current user's timezone
-(`22.5` means 22:30 local time) and is converted at runtime to the next
-matching UTC datetime used as the queue job ETA.
+Each exchange type can optionally route its jobs to a specific channel, set a
+priority, or **hold all jobs until a fixed time of day** — useful when a
+trading partner's receiving system has a nightly processing window or when the
+operator wants to concentrate resource-intensive EDI work in off-peak hours.

--- a/edi_queue_oca/readme/DESCRIPTION.md
+++ b/edi_queue_oca/readme/DESCRIPTION.md
@@ -1,3 +1,8 @@
 This module integrates EDI with Queue Job and now the edi exchange records are generated using queue.
 
 No need of doing a configuration on it, however, we can specify priority and channel in exchange type.
+
+Exchange types can also define a daily execution time with `eta_time`.
+The value is entered as a `float_time` in the current user's timezone
+(`22.5` means 22:30 local time) and is converted at runtime to the next
+matching UTC datetime used as the queue job ETA.

--- a/edi_queue_oca/readme/USAGE.md
+++ b/edi_queue_oca/readme/USAGE.md
@@ -1,0 +1,52 @@
+## Automatic job dispatch
+
+All exchange actions on `edi.exchange.record` are dispatched as background
+jobs automatically. No per-record configuration is required; the integration
+is active for every exchange type as soon as the module is installed.
+
+## Per-type job configuration
+
+Each **Exchange Type** gains a *Queue* tab with optional settings:
+
+| Field | Purpose |
+|---|---|
+| **Job channel** | Route jobs to a specific channel (e.g. `root.edi.high`). |
+| **Job priority** | Integer priority passed to the queue job (lower = higher priority). |
+| **Enable ETA Scheduling** | Toggle to activate daily job accumulation (see below). |
+| **Execution time** | Hour, minute, and timezone at which accumulated jobs are released. Visible only when ETA Scheduling is enabled. |
+
+## Accumulating jobs until a fixed daily time
+
+Enabling **ETA Scheduling** on an exchange type causes every job created for
+that type to be **held in the queue** until the configured time of day, rather
+than being processed immediately. All jobs that arrive during the day
+accumulate and are released together at that moment.
+
+**Typical use cases:**
+
+- A trading partner's receiving system only processes incoming files at a
+  specific nightly window (e.g. 22:00).
+- Resource-intensive EDI operations (large exports, heavy transformations)
+  should be deferred to off-peak hours to avoid competing with daytime
+  workloads.
+- Operational preference to send a batch of documents at a predictable daily
+  time instead of dispatching them one by one in real time.
+
+The execution time is configured with three fields:
+
+- **Hour** — hour of the day (00–23).
+- **Minute** — minute of the hour (00–59).
+- **Timezone** — the timezone in which the hour and minute are interpreted.
+  Defaults to the current user's timezone.
+
+At runtime the configured time is converted to the next matching UTC datetime
+and set as the queue job ETA. If the target time for today has already passed,
+the job is automatically scheduled for the same time tomorrow.
+
+When **Enable ETA Scheduling** is off, jobs are dispatched immediately as
+usual.
+
+## Duplicate-job prevention
+
+An identity key is attached to every queued job, so re-triggering an action
+for a record that already has a pending job does not enqueue a duplicate.

--- a/edi_queue_oca/static/description/index.html
+++ b/edi_queue_oca/static/description/index.html
@@ -379,6 +379,10 @@ ul.auto-toc {
 records are generated using queue.</p>
 <p>No need of doing a configuration on it, however, we can specify priority
 and channel in exchange type.</p>
+<p>Exchange types can also define a daily execution time with <tt class="docutils literal">eta_time</tt>.
+The value is entered as a <tt class="docutils literal">float_time</tt> in the current user’s timezone
+(<tt class="docutils literal">22.5</tt> means 22:30 local time) and is converted at runtime to the
+next matching UTC datetime used as the queue job ETA.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/edi_queue_oca/static/description/index.html
+++ b/edi_queue_oca/static/description/index.html
@@ -375,28 +375,116 @@ ul.auto-toc {
 !! source digest: sha256:186ea8dc51c0216b5067f4cc29ed5c478a91fad07c648bcb9d0ac21d303da33b
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/edi-framework/tree/19.0/edi_queue_oca"><img alt="OCA/edi-framework" src="https://img.shields.io/badge/github-OCA%2Fedi--framework-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/edi-framework-19-0/edi-framework-19-0-edi_queue_oca"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/edi-framework&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module integrates EDI with Queue Job and now the edi exchange
-records are generated using queue.</p>
-<p>No need of doing a configuration on it, however, we can specify priority
-and channel in exchange type.</p>
-<p>Exchange types can also define a daily execution time with <tt class="docutils literal">eta_time</tt>.
-The value is entered as a <tt class="docutils literal">float_time</tt> in the current user’s timezone
-(<tt class="docutils literal">22.5</tt> means 22:30 local time) and is converted at runtime to the
-next matching UTC datetime used as the queue job ETA.</p>
+<p>This module integrates EDI exchange records with <a class="reference external" href="https://github.com/OCA/queue">Queue
+Job</a>, so that the four core exchange
+actions — <strong>generate</strong>, <strong>send</strong>, <strong>receive</strong>, and <strong>process</strong> — are
+dispatched as background jobs instead of running synchronously.</p>
+<p>Each exchange type can optionally route its jobs to a specific channel,
+set a priority, or <strong>hold all jobs until a fixed time of day</strong> — useful
+when a trading partner’s receiving system has a nightly processing
+window or when the operator wants to concentrate resource-intensive EDI
+work in off-peak hours.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a><ul>
+<li><a class="reference internal" href="#automatic-job-dispatch" id="toc-entry-2">Automatic job dispatch</a></li>
+<li><a class="reference internal" href="#per-type-job-configuration" id="toc-entry-3">Per-type job configuration</a></li>
+<li><a class="reference internal" href="#accumulating-jobs-until-a-fixed-daily-time" id="toc-entry-4">Accumulating jobs until a fixed daily time</a></li>
+<li><a class="reference internal" href="#duplicate-job-prevention" id="toc-entry-5">Duplicate-job prevention</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-8">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-9">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="usage">
+<h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
+<div class="section" id="automatic-job-dispatch">
+<h3><a class="toc-backref" href="#toc-entry-2">Automatic job dispatch</a></h3>
+<p>All exchange actions on <tt class="docutils literal">edi.exchange.record</tt> are dispatched as
+background jobs automatically. No per-record configuration is required;
+the integration is active for every exchange type as soon as the module
+is installed.</p>
+</div>
+<div class="section" id="per-type-job-configuration">
+<h3><a class="toc-backref" href="#toc-entry-3">Per-type job configuration</a></h3>
+<p>Each <strong>Exchange Type</strong> gains a <em>Queue</em> tab with optional settings:</p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="39%" />
+<col width="61%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Field</th>
+<th class="head">Purpose</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td><strong>Job channel</strong></td>
+<td>Route jobs to a specific channel (e.g.
+<tt class="docutils literal">root.edi.high</tt>).</td>
+</tr>
+<tr><td><strong>Job priority</strong></td>
+<td>Integer priority passed to the queue job
+(lower = higher priority).</td>
+</tr>
+<tr><td><strong>Enable ETA Scheduling</strong></td>
+<td>Toggle to activate daily job
+accumulation (see below).</td>
+</tr>
+<tr><td><strong>Execution time</strong></td>
+<td>Hour, minute, and timezone at which
+accumulated jobs are released. Visible
+only when ETA Scheduling is enabled.</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="accumulating-jobs-until-a-fixed-daily-time">
+<h3><a class="toc-backref" href="#toc-entry-4">Accumulating jobs until a fixed daily time</a></h3>
+<p>Enabling <strong>ETA Scheduling</strong> on an exchange type causes every job created
+for that type to be <strong>held in the queue</strong> until the configured time of
+day, rather than being processed immediately. All jobs that arrive
+during the day accumulate and are released together at that moment.</p>
+<p><strong>Typical use cases:</strong></p>
+<ul class="simple">
+<li>A trading partner’s receiving system only processes incoming files at
+a specific nightly window (e.g. 22:00).</li>
+<li>Resource-intensive EDI operations (large exports, heavy
+transformations) should be deferred to off-peak hours to avoid
+competing with daytime workloads.</li>
+<li>Operational preference to send a batch of documents at a predictable
+daily time instead of dispatching them one by one in real time.</li>
+</ul>
+<p>The execution time is configured with three fields:</p>
+<ul class="simple">
+<li><strong>Hour</strong> — hour of the day (00–23).</li>
+<li><strong>Minute</strong> — minute of the hour (00–59).</li>
+<li><strong>Timezone</strong> — the timezone in which the hour and minute are
+interpreted. Defaults to the current user’s timezone.</li>
+</ul>
+<p>At runtime the configured time is converted to the next matching UTC
+datetime and set as the queue job ETA. If the target time for today has
+already passed, the job is automatically scheduled for the same time
+tomorrow.</p>
+<p>When <strong>Enable ETA Scheduling</strong> is off, jobs are dispatched immediately
+as usual.</p>
+</div>
+<div class="section" id="duplicate-job-prevention">
+<h3><a class="toc-backref" href="#toc-entry-5">Duplicate-job prevention</a></h3>
+<p>An identity key is attached to every queued job, so re-triggering an
+action for a record that already has a pending job does not enqueue a
+duplicate.</p>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/edi-framework/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -404,16 +492,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Authors</a></h3>
 <ul class="simple">
 <li>Dixmit</li>
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-9">Contributors</a></h3>
 <ul class="simple">
 <li>Simone Orsi &lt;<a class="reference external" href="mailto:simahawk&#64;gmail.com">simahawk&#64;gmail.com</a>&gt;</li>
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:enric.tobella&#64;dixmit.com">enric.tobella&#64;dixmit.com</a>&gt;</li>
@@ -423,7 +511,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/edi_queue_oca/tests/__init__.py
+++ b/edi_queue_oca/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_exchange_type
 from . import test_record
 from . import test_backend_jobs
 from . import test_backend_output_jobs

--- a/edi_queue_oca/tests/common.py
+++ b/edi_queue_oca/tests/common.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.edi_core_oca.tests.common import EDIBackendCommonTestCase
+
+
+class EDIQueueCommonTestCase(EDIBackendCommonTestCase):
+    def _make_record(self):
+        return self.backend.create_record(
+            "test_csv_input",
+            {"model": self.partner._name, "res_id": self.partner.id},
+        )
+
+    def _get_delayed(self, record):
+        delayed = record.with_context(queue_job__no_delay=False).with_delay()
+        # Suppress "prepared but never delayed" warning
+        # `Delayable Delayable(edi.exchange.record*) was prepared but never delayed`
+        delayed.delayable._generated_job = object()
+        return delayed

--- a/edi_queue_oca/tests/test_exchange_type.py
+++ b/edi_queue_oca/tests/test_exchange_type.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from .common import EDIQueueCommonTestCase
+
+
+class EDIExchangeTypeTestCase(EDIQueueCommonTestCase):
+    def setUp(self):
+        super().setUp()
+        self.record = self._make_record()
+
+    def _get_job_eta(self, record):
+        return self._get_delayed(record).delayable.eta
+
+    def test_job_eta_disabled_no_eta_applied(self):
+        """job_eta_enabled=False: no ETA is set regardless of value."""
+        self.exchange_type_in.job_eta_hour = "22"
+        self.exchange_type_in.job_eta_minute = "00"
+        # job_eta_enabled defaults to False
+        self.assertIsNone(self._get_job_eta(self.record))
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_job_eta_scheduled_same_day(self):
+        """ETA not yet reached today: job lands on the same calendar day."""
+        self.env.user.tz = "UTC"
+        self.exchange_type_in.job_eta_enabled = True
+        self.exchange_type_in.job_eta_hour = "22"
+        self.exchange_type_in.job_eta_minute = "00"
+        self.assertEqual(
+            self._get_job_eta(self.record),
+            datetime(2024, 1, 15, 22, 0, 0),
+        )
+
+    @freeze_time("2024-01-15 23:00:00")
+    def test_job_eta_scheduled_next_day(self):
+        """ETA already passed today: job rolls over to the next calendar day."""
+        self.env.user.tz = "UTC"
+        self.exchange_type_in.job_eta_enabled = True
+        self.exchange_type_in.job_eta_hour = "22"
+        self.exchange_type_in.job_eta_minute = "00"
+        self.assertEqual(
+            self._get_job_eta(self.record),
+            datetime(2024, 1, 16, 22, 0, 0),
+        )
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_job_eta_midnight_schedules_next_day(self):
+        """Midnight (00:00) schedules for the next 00:00 in user TZ."""
+        self.env.user.tz = "UTC"
+        self.exchange_type_in.job_eta_enabled = True
+        self.exchange_type_in.job_eta_hour = "00"
+        self.exchange_type_in.job_eta_minute = "00"
+        self.assertEqual(
+            self._get_job_eta(record=self.record),
+            datetime(2024, 1, 16, 0, 0, 0),
+        )

--- a/edi_queue_oca/tests/test_record.py
+++ b/edi_queue_oca/tests/test_record.py
@@ -3,18 +3,18 @@
 # @author: Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from datetime import datetime
 
-from odoo.addons.edi_core_oca.tests.common import EDIBackendCommonTestCase
+import pytz
+
 from odoo.addons.queue_job.delay import DelayableRecordset
 
+from .common import EDIQueueCommonTestCase
 
-class EDIRecordTestCase(EDIBackendCommonTestCase):
+
+class EDIRecordTestCase(EDIQueueCommonTestCase):
     def test_with_delay_override(self):
-        vals = {
-            "model": self.partner._name,
-            "res_id": self.partner.id,
-        }
-        record = self.backend.create_record("test_csv_input", vals)
+        record = self._make_record()
         parent_channel = self.env["queue.job.channel"].create(
             {
                 "name": "parent_test_chan",
@@ -27,11 +27,38 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
         self.exchange_type_in.job_channel_id = channel
         self.exchange_type_in.job_priority = 5
         # re-enable job delayed feature
-        delayed = record.with_context(queue_job__no_delay=False).with_delay()
-        # Silent useless warning
-        # `Delayable Delayable(edi.exchange.record*) was prepared but never delayed`
-        delayed.delayable._generated_job = object()
+        delayed = self._get_delayed(record)
         self.assertTrue(isinstance(delayed, DelayableRecordset))
         self.assertEqual(delayed.recordset, record)
+        self.assertEqual(delayed.delayable.channel, "root.parent_test_chan.test_chan")
+        self.assertEqual(delayed.delayable.priority, 5)
+
+    def test_with_delay_job_eta_applied(self):
+        record = self._make_record()
+        parent_channel = self.env["queue.job.channel"].create(
+            {
+                "name": "parent_test_chan",
+                "parent_id": self.env.ref("queue_job.channel_root").id,
+            }
+        )
+        channel = self.env["queue.job.channel"].create(
+            {"name": "test_chan", "parent_id": parent_channel.id}
+        )
+        self.exchange_type_in.job_channel_id = channel
+        self.exchange_type_in.job_priority = 5
+        self.exchange_type_in.job_eta_enabled = True
+        self.exchange_type_in.job_eta_hour = "22"
+        self.exchange_type_in.job_eta_minute = "00"
+        delayed = self._get_delayed(record)
+        job_eta = delayed.delayable.eta
+        utc_tz = pytz.UTC
+        user_tz = pytz.timezone(self.env.user.tz or "UTC")
+        target_22h_user = datetime.now(user_tz).replace(
+            hour=22, minute=0, second=0, microsecond=0
+        )
+        expected_eta = target_22h_user.astimezone(utc_tz).replace(tzinfo=None)
+        self.assertTrue(isinstance(delayed, DelayableRecordset))
+        self.assertEqual(delayed.recordset, record)
+        self.assertEqual(job_eta, expected_eta)
         self.assertEqual(delayed.delayable.channel, "root.parent_test_chan.test_chan")
         self.assertEqual(delayed.delayable.priority, 5)

--- a/edi_queue_oca/views/edi_exchange_type.xml
+++ b/edi_queue_oca/views/edi_exchange_type.xml
@@ -11,6 +11,22 @@
                     <group>
                         <field name="job_channel_id" />
                         <field name="job_priority" />
+                        <field name="job_eta_enabled" />
+                        <field
+                            name="job_eta_hour"
+                            invisible="not job_eta_enabled"
+                            required="job_eta_enabled"
+                        />
+                        <field
+                            name="job_eta_minute"
+                            invisible="not job_eta_enabled"
+                            required="job_eta_enabled"
+                        />
+                        <field
+                            name="job_eta_tz"
+                            invisible="not job_eta_enabled"
+                            required="job_eta_enabled"
+                        />
                     </group>
                 </page>
             </notebook>


### PR DESCRIPTION
This pull request introduces an enhancement to the EDI Queue OCA module by allowing EDI exchange jobs to be scheduled and accumulated for release at a specific daily time, in addition to existing per-type channel and priority configuration. 

**New job scheduling and accumulation features:**

* Added fields to `edi.exchange.type` for enabling ETA scheduling, configuring execution hour, minute, and timezone, and logic to compute the next scheduled runtime in UTC. This allows all jobs for a given exchange type to be held and released together at a fixed time each day, supporting off-peak processing and trading partner requirements.
* Modified job dispatch logic so that, if ETA scheduling is enabled, jobs are queued with the calculated ETA; otherwise, jobs are dispatched immediately as before.


**Accumulating jobs until a fixed daily time**

Enabling ETA scheduling on an exchange type causes every job created for that type to be held in the queue until the configured time of day, rather than being processed immediately. All jobs that arrive during the day accumulate and are released together at that scheduled time.

Typical use cases:

- A trading partner's receiving system processes incoming files only during a specific nightly window (e.g., 22:00).
- Resource-intensive EDI operations (large exports, heavy transformations) are deferred to off-peak hours to avoid competing with daytime workloads.
- An operational preference to send a batch of documents at a predictable daily time instead of dispatching them one by one in real time.

**The execution time is configured using three fields:**
- Hour — hour of the day (00–23)
- Minute — minute of the hour (00–59)
- Timezone — the timezone in which the hour and minute are interpreted; defaults to the current user's timezone

At runtime, the configured time is converted to the next matching UTC datetime and set as the queue job ETA. If the target time for the current day has already passed, the job is automatically scheduled for the same time on the next day.

**When ETA scheduling is disabled, jobs are dispatched immediately as usual.**
