### PR TITLE
[19.0][IMP] edi_core_oca: align with v19 (pretty URLs, t-out)

### DIFF
--- a/edi_core_oca/templates/exchange_chatter_msg.xml
+++ b/edi_core_oca/templates/exchange_chatter_msg.xml
@@ -5,11 +5,19 @@
             t-set="message_color_klass"
             t-value="{'error': 'text-danger', 'warning': 'text-warning'}"
         />
+        <t
+            t-set="exchange_record_path"
+            t-value="env.ref('edi_core_oca.act_open_edi_exchange_record_view').path"
+        />
+        <t
+            t-set="exc_type_path"
+            t-value="env.ref('edi_core_oca.act_open_edi_exchange_type_view').path"
+        />
         <p t-attf-class="edi-exchange level-#{level}">
             <span class="edi-exchange-ref">
                 <strong>EDI exchange:</strong>
                 <a
-                    t-attf-href="/web#id=#{exchange_record.id}&amp;model=#{exchange_record._name}&amp;view_type=form"
+                    t-attf-href="/odoo/#{exchange_record_path}/#{exchange_record.id}"
                     t-att-data-oe-model="exchange_record._name"
                     t-att-data-oe-id="exchange_record.id"
                 >
@@ -21,7 +29,7 @@
             <span class="edi-exchange-type">
                 <strong>Type:</strong>
                 <a
-                    t-attf-href="/web#id=#{exc_type.id}&amp;model=#{exc_type._name}&amp;view_type=form"
+                    t-attf-href="/odoo/#{exc_type_path}/#{exc_type.id}"
                     t-att-data-oe-model="exc_type._name"
                     t-att-data-oe-id="exc_type.id"
                 >

--- a/edi_core_oca/templates/exchange_chatter_msg.xml
+++ b/edi_core_oca/templates/exchange_chatter_msg.xml
@@ -21,7 +21,7 @@
                     t-att-data-oe-model="exchange_record._name"
                     t-att-data-oe-id="exchange_record.id"
                 >
-                    <t t-esc="exchange_record.identifier" />
+                    <t t-out="exchange_record.identifier" />
                 </a>
             </span>
             <br />
@@ -33,7 +33,7 @@
                     t-att-data-oe-model="exc_type._name"
                     t-att-data-oe-id="exc_type.id"
                 >
-                    <t t-esc="exc_type.name" />
+                    <t t-out="exc_type.name" />
                 </a>
             </span>
             <br />
@@ -44,7 +44,7 @@
             <br />
             <span t-attf-class="exchange-message #{message_color_klass.get(level)}">
                 <strong>Message:</strong>
-                <span t-esc="message" />
+                <span t-out="message" />
             </span>
         </p>
     </template>

--- a/edi_core_oca/views/edi_backend_type_views.xml
+++ b/edi_core_oca/views/edi_backend_type_views.xml
@@ -33,6 +33,7 @@
     </record>
     <record model="ir.actions.act_window" id="act_open_edi_backend_type_view">
         <field name="name">EDI Backend Type</field>
+        <field name="path">edi-backend-types</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.backend.type</field>
         <field name="view_mode">list,form</field>

--- a/edi_core_oca/views/edi_backend_views.xml
+++ b/edi_core_oca/views/edi_backend_views.xml
@@ -100,6 +100,7 @@
     </record>
     <record model="ir.actions.act_window" id="act_open_edi_backend_view">
         <field name="name">EDI Backend</field>
+        <field name="path">edi-backends</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.backend</field>
         <field name="view_mode">list,form</field>

--- a/edi_core_oca/views/edi_configuration_views.xml
+++ b/edi_core_oca/views/edi_configuration_views.xml
@@ -91,6 +91,7 @@
     </record>
     <record model="ir.actions.act_window" id="act_open_edi_configuration_view">
         <field name="name">EDI Configuration</field>
+        <field name="path">edi-configurations</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.configuration</field>
         <field name="view_mode">list,form</field>

--- a/edi_core_oca/views/edi_exchange_record_views.xml
+++ b/edi_core_oca/views/edi_exchange_record_views.xml
@@ -330,6 +330,7 @@
 
     <record model="ir.actions.act_window" id="act_open_edi_exchange_record_recent_view">
         <field name="name">Recent exchanges</field>
+        <field name="path">edi-exchange-records-recent</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.record</field>
         <field name="view_mode">list,form</field>
@@ -343,6 +344,7 @@
 
     <record model="ir.actions.act_window" id="act_open_edi_exchange_record_view">
         <field name="name">Exchanges</field>
+        <field name="path">edi-exchange-records</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.record</field>
         <field name="view_mode">list,form</field>
@@ -356,6 +358,7 @@
         id="act_open_edi_exchange_record_view_pending"
     >
         <field name="name">Exchanges - pending</field>
+        <field name="path">edi-exchange-records-pending</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.record</field>
         <field name="view_mode">list,form</field>
@@ -368,6 +371,7 @@
 
     <record model="ir.actions.act_window" id="act_open_edi_exchange_record_view_failed">
         <field name="name">Exchanges - failed</field>
+        <field name="path">edi-exchange-records-failed</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.record</field>
         <field name="view_mode">list,form</field>
@@ -383,6 +387,7 @@
         id="act_open_edi_exchange_record_view_inbound"
     >
         <field name="name">Exchanges - inbound</field>
+        <field name="path">edi-exchange-records-inbound</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.record</field>
         <field name="view_mode">list,form</field>
@@ -398,6 +403,7 @@
         id="act_open_edi_exchange_record_view_outbound"
     >
         <field name="name">Exchanges - outbound</field>
+        <field name="path">edi-exchange-records-outbound</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.record</field>
         <field name="view_mode">list,form</field>

--- a/edi_core_oca/views/edi_exchange_type_rule_views.xml
+++ b/edi_core_oca/views/edi_exchange_type_rule_views.xml
@@ -114,6 +114,7 @@
     </record>
     <record model="ir.actions.act_window" id="act_open_edi_exchange_type_rule_view">
         <field name="name">EDI Exchange Type Rule</field>
+        <field name="path">edi-exchange-type-rules</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.type.rule</field>
         <field name="view_mode">list,form</field>

--- a/edi_core_oca/views/edi_exchange_type_views.xml
+++ b/edi_core_oca/views/edi_exchange_type_views.xml
@@ -204,6 +204,7 @@
     </record>
     <record model="ir.actions.act_window" id="act_open_edi_exchange_type_view">
         <field name="name">EDI Exchange Type</field>
+        <field name="path">edi-exchange-types</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">edi.exchange.type</field>
         <field name="view_mode">list,form</field>


### PR DESCRIPTION
Improve UI/UX in edi_core_oca module:
- [x] Add paths to edi models to avoid having action-<number> in the URL
- [x] Fix some warning errors:

```
2026-07-13 13:46:34,412 1 WARNING devel odoo.addons.base.models.ir_qweb: Found deprecated directive @t-esc='exchange_record.identifier' in template 4066. Replace by @t-out 
2026-07-13 13:46:34,418 1 WARNING devel odoo.addons.base.models.ir_qweb: Found deprecated directive @t-esc='exc_type.name' in template 4066. Replace by @t-out 
2026-07-13 13:46:34,426 1 WARNING devel odoo.addons.base.models.ir_qweb: Found deprecated directive @t-esc='message' in template 4066. Replace by @t-out 
```