### PR TITLE
[18.0] edi_exchange_template: deprecate nswrapper usage

### DIFF
--- a/edi_exchange_template_oca/tests/test_nswrapper.py
+++ b/edi_exchange_template_oca/tests/test_nswrapper.py
@@ -43,13 +43,29 @@ XML2 = """
 
 class TestNSWrapper(TransactionCase):
     def test_purge1(self):
-        res = xml_purge_nswrapper(XML1)
+        with self.assertLogs(
+            "odoo.addons.edi_exchange_template_oca.utils", level="WARNING"
+        ):
+            res = xml_purge_nswrapper(XML1)
         self.assertNotIn("nswrapper", str(res))
 
     def test_purge2(self):
-        res = xml_purge_nswrapper(XML2)
+        with self.assertLogs(
+            "odoo.addons.edi_exchange_template_oca.utils", level="WARNING"
+        ):
+            res = xml_purge_nswrapper(XML2)
         self.assertNotIn("nswrapper", str(res))
 
     def test_purge3(self):
-        res = xml_purge_nswrapper(ORDER_RESP_WRAPPER_TMPL.format(XML2))
+        with self.assertLogs(
+            "odoo.addons.edi_exchange_template_oca.utils", level="WARNING"
+        ):
+            res = xml_purge_nswrapper(ORDER_RESP_WRAPPER_TMPL.format(XML2))
+        self.assertNotIn("nswrapper", str(res))
+
+    def test_no_nswrapper_no_warning(self):
+        with self.assertNoLogs(
+            "odoo.addons.edi_exchange_template_oca.utils", level="WARNING"
+        ):
+            res = xml_purge_nswrapper("<Foo><Bar>baz</Bar></Foo>")
         self.assertNotIn("nswrapper", str(res))

--- a/edi_exchange_template_oca/utils.py
+++ b/edi_exchange_template_oca/utils.py
@@ -3,11 +3,26 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import logging
+
 from lxml import etree
+
+_logger = logging.getLogger(__name__)
 
 
 def xml_purge_nswrapper(xml_content):
     """Purge `nswrapper` elements.
+
+    .. deprecated::
+        The `nswrapper` trick is deprecated. Declare namespaces directly
+        on a `<t>` element instead, as `t` is never rendered to output:
+
+            <t xmlns:foo="http://www.unece.org/cefact/Foo">
+                <foo:LovelyNamespacedElement />
+            </t>
+
+        This function is kept only for backward compatibility with
+        templates still using the old `nswrapper` element.
 
     QWeb template does not allow parsing namespaced elements
     without declaring namespaces on the root element.
@@ -15,9 +30,9 @@ def xml_purge_nswrapper(xml_content):
     Hence, by default you cannot define smaller re-usable templates
     if the have namespaced elements.
 
-    The trick is to wrap your reusable template with `nswrapper` element
-    which holds the namespace for that particular sub template.
-    For instance:
+    The (deprecated) trick was to wrap your reusable template with an
+    `nswrapper` element which holds the namespace for that particular
+    sub template. For instance:
 
         <nswrapper xmlns:foo="http://www.unece.org/cefact/Foo">
             <foo:LovelyNamespacedElement />
@@ -30,7 +45,13 @@ def xml_purge_nswrapper(xml_content):
     root = etree.XML(xml_content)
     # Deeper elements come after, keep the root element at the end (if any).
     # Use `name()` because the real element could be namespaced on render.
-    for nswrapper in reversed(root.xpath("//*[name() = 'nswrapper']")):
+    nswrappers = root.xpath("//*[name() = 'nswrapper']")
+    if nswrappers:
+        _logger.warning(
+            "Deprecated `nswrapper` element found. "
+            "Use a `<t>` element to declare namespaces instead."
+        )
+    for nswrapper in reversed(nswrappers):
         parent = nswrapper.getparent()
         if parent is None:
             # fmt:off

--- a/edi_sale_ubl_output_oca/templates/qweb_tmpl_party.xml
+++ b/edi_sale_ubl_output_oca/templates/qweb_tmpl_party.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <!--
-        `nswrapper` is a trick to be able to import these templates
-        as XML because a namespace is mandatory for element prefixes.
-        `nswrapper` elements are purged afterwards in post-processing.
-        -->
     <!-- TODO: move to edi_ubl? -->
     <template id="qweb_tmpl_ubl_party" name="Render UBL party">
-        <nswrapper
+        <t
             xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
         >
@@ -30,11 +25,11 @@
                     <cbc:Name t-esc="party.name">Moderna Produkter AB</cbc:Name>
                 </cac:PartyName>
             </cac:Party>
-        </nswrapper>
+        </t>
     </template>
 
     <template id="qweb_tmpl_ubl_address" name="Render UBL party address">
-        <nswrapper
+        <t
             xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
         >
@@ -47,6 +42,6 @@
             <cac:Country t-if="partner.country_id">
                 <cbc:IdentificationCode t-field="partner.country_id" />
             </cac:Country>
-        </nswrapper>
+        </t>
     </template>
 </odoo>


### PR DESCRIPTION
The `nswrapper` trick is deprecated. Declare namespaces directly
        on a `<t>` element instead, as `t` is never rendered to output:

``` 
            <t xmlns:foo="http://www.unece.org/cefact/Foo">
                <foo:LovelyNamespacedElement />
            </t>
``` 
 This function is kept only for backward compatibility with
templates still using the old `nswrapper` element.