### PR TITLE
[FIX] edi_record_metadata_oca: hide metadata page when empty

### DIFF
--- a/edi_record_metadata_oca/models/edi_exchange_record.py
+++ b/edi_record_metadata_oca/models/edi_exchange_record.py
@@ -21,7 +21,11 @@ class EDIExchangeRecord(models.Model):
     @api.depends("metadata")
     def _compute_metadata_display(self):
         for rec in self:
-            rec.metadata_display = json.dumps(rec.metadata, sort_keys=True, indent=4)
+            rec.metadata_display = (
+                json.dumps(rec.metadata, sort_keys=True, indent=4)
+                if rec.metadata
+                else False
+            )
 
     def edi_set_metadata(self, data):
         self.metadata = data

--- a/edi_record_metadata_oca/tests/test_metadata.py
+++ b/edi_record_metadata_oca/tests/test_metadata.py
@@ -40,6 +40,10 @@ class TestEDIMetadata(EDIBackendCommonTestCase):
         self.assertTrue(self.exc_record.metadata)
         self.assertTrue(self.exc_record.metadata_display)
 
+    def test_fields_no_metadata(self):
+        self.assertFalse(self.exc_record.metadata)
+        self.assertFalse(self.exc_record.metadata_display)
+
     def test_no_store(self):
         consumer_record = self.consumer_model.create(
             {

--- a/edi_record_metadata_oca/views/edi_exchange_record.xml
+++ b/edi_record_metadata_oca/views/edi_exchange_record.xml
@@ -5,7 +5,12 @@
         <field name="inherit_id" ref="edi_core_oca.edi_exchange_record_view_form" />
         <field name="arch" type="xml">
             <page name="related_records" position="after">
-                <page name="metadata" string="Metadata" groups="base.group_no_one">
+                <page
+                    name="metadata"
+                    string="Metadata"
+                    groups="base.group_no_one"
+                    invisible="not metadata_display"
+                >
                     <group name="metadata">
                         <field name="metadata_display" />
                     </group>


### PR DESCRIPTION
Hide the Metadata page when the record has no metadata, to avoid showing this:


<img width="1096" height="618" alt="Screenshot 2026-08-13 at 2 07 03 PM" src="https://github.com/user-attachments/assets/8de769d3-6c7a-4473-9cdc-8964bbdae73f" />

