### PR TITLE
[19.0] [IMP] edi_core_oca, edi_queue_oca: chain receive and process

### DIFF
--- a/edi_core_oca/models/edi_backend.py
+++ b/edi_core_oca/models/edi_backend.py
@@ -623,7 +623,9 @@ class EDIBackend(models.Model):
             len(pending_records),
         )
         for rec in pending_records:
-            rec.action_exchange_receive()
+            # Chained, so a record does not have to wait for the next run of
+            # this cron to be processed once it has been received.
+            rec.action_exchange_receive_process_chained()
 
         pending_process_records = self.exchange_record_model.search(
             self._input_pending_process_records_domain(record_ids=record_ids)

--- a/edi_core_oca/models/edi_exchange_record.py
+++ b/edi_core_oca/models/edi_exchange_record.py
@@ -698,3 +698,7 @@ class EDIExchangeRecord(models.Model):
     def action_exchange_generate_send_chained(self):
         self.action_exchange_generate()
         self.action_exchange_send()
+
+    def action_exchange_receive_process_chained(self):
+        self.action_exchange_receive()
+        self.action_exchange_process()

--- a/edi_core_oca/tests/test_backend_input.py
+++ b/edi_core_oca/tests/test_backend_input.py
@@ -48,6 +48,31 @@ class EDIBackendTestInputCase(EDIBackendCommonTestCase):
     def setUp(self):
         super().setUp()
         self.ExecutionAbstractModel.reset_faked("receive")
+        self.ExecutionAbstractModel.reset_faked("process")
+
+    def test_input_sync_receives_and_processes_in_one_pass(self):
+        """A record the scheduled action receives is processed by the same run.
+
+        Scenario:
+            1. A record is waiting to be received.
+            2. Run the input sync once.
+        Expected:
+            - It is received and then processed, without waiting for the
+              scheduled action to come round again.
+        """
+        self.record.edi_exchange_state = "input_pending"
+
+        self.backend.with_context(fake_output="yeah!")._check_input_exchange_sync()
+
+        self.assertTrue(
+            self.ExecutionAbstractModel.check_called_for(self.record, "receive")
+        )
+        self.assertTrue(
+            self.ExecutionAbstractModel.check_called_for(self.record, "process")
+        )
+        self.assertRecordValues(
+            self.record, [{"edi_exchange_state": "input_processed"}]
+        )
 
     def test_receive_record_nothing_todo(self):
         self.backend.with_context(fake_output="yeah!").exchange_receive(self.record)

--- a/edi_queue_oca/models/edi_exchange_record.py
+++ b/edi_queue_oca/models/edi_exchange_record.py
@@ -103,6 +103,13 @@ class EdiExchangeRecord(models.Model):
         job1.on_done(self.delayable(priority=0).action_exchange_send())
         job1.delay()
 
+    def action_exchange_receive_process_chained(self):
+        job1 = self.delayable().action_exchange_receive()
+        # Chain process job.
+        # Raise prio to max to process the record as soon as it lands.
+        job1.on_done(self.delayable(priority=0).action_exchange_process())
+        job1.delay()
+
     def _job_on_fail_generate(self, **kw):
         return self._job_on_fail_update("validate_error", **kw)
 

--- a/edi_queue_oca/tests/__init__.py
+++ b/edi_queue_oca/tests/__init__.py
@@ -1,6 +1,7 @@
 from . import test_exchange_type
 from . import test_record
 from . import test_backend_jobs
+from . import test_backend_input_jobs
 from . import test_backend_output_jobs
 
 

--- a/edi_queue_oca/tests/test_backend_input_jobs.py
+++ b/edi_queue_oca/tests/test_backend_input_jobs.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.tests import tagged
+
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import EDIQueueCommonTestCase
+
+
+@tagged("-at_install", "post_install")
+class EDIBackendTestInputJobsCase(EDIQueueCommonTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.record = cls.backend.create_record(
+            "test_csv_input",
+            {
+                "model": cls.partner._name,
+                "res_id": cls.partner.id,
+                "edi_exchange_state": "input_pending",
+            },
+        )
+
+    @classmethod
+    def _setup_context(cls):
+        # Re-enable jobs
+        return dict(super()._setup_context(), queue_job__no_delay=False)
+
+    def test_receive_process_chained(self):
+        """Receiving and processing a record queues one chain of two jobs.
+
+        Scenario:
+            1. Ask a pending input record to be received and processed.
+            2. Run the queued jobs.
+        Expected:
+            - A receive job and a process job are queued.
+            - The process job waits for the receive job and gets the top priority.
+            - Once both ran, the record has been processed.
+        """
+        with trap_jobs() as trap:
+            self.record.action_exchange_receive_process_chained()
+            trap.assert_jobs_count(2)
+            trap.assert_enqueued_job(self.record.action_exchange_receive)
+            trap.assert_enqueued_job(
+                self.record.action_exchange_process, properties={"priority": 0}
+            )
+            process_job, receive_job = sorted(
+                trap.enqueued_jobs, key=lambda job: job.method_name
+            )
+            self.assertEqual(process_job.depends_on, {receive_job})
+            trap.perform_enqueued_jobs()
+        self.assertRecordValues(
+            self.record, [{"edi_exchange_state": "input_processed"}]
+        )

--- a/edi_queue_oca/tests/test_backend_output_jobs.py
+++ b/edi_queue_oca/tests/test_backend_output_jobs.py
@@ -69,4 +69,28 @@ class EDIBackendTestOutputJobsCase(EDIBackendCommonTestCase):
             job = self.record.action_exchange_send()
             self.assertEqual(0, job.priority)
             trap.assert_jobs_count(4)
-        # TODO: test input in the same way
+
+    def test_generate_send_chained(self):
+        """Generating and sending a record queues one chain of two jobs.
+
+        Scenario:
+            1. Ask a new output record to be generated and sent.
+            2. Run the queued jobs.
+        Expected:
+            - A generate job and a send job are queued.
+            - The send job waits for the generate job and gets the top priority.
+            - Once both ran, the record has been sent.
+        """
+        with trap_jobs() as trap:
+            self.record.action_exchange_generate_send_chained()
+            trap.assert_jobs_count(2)
+            trap.assert_enqueued_job(self.record.action_exchange_generate)
+            trap.assert_enqueued_job(
+                self.record.action_exchange_send, properties={"priority": 0}
+            )
+            generate_job, send_job = sorted(
+                trap.enqueued_jobs, key=lambda job: job.method_name
+            )
+            self.assertEqual(send_job.depends_on, {generate_job})
+            trap.perform_enqueued_jobs()
+        self.assertRecordValues(self.record, [{"edi_exchange_state": "output_sent"}])


### PR DESCRIPTION
An input record was received and then left for the next run of the input cron to be processed, up to an hour later. Chain the two the way generate and send already are, so a document is processed as soon as it lands.