### PR TITLE
[19.0] [FIX] edi_queue_oca: on fail hook with non string exception message

### DIFF
--- a/edi_queue_oca/models/edi_exchange_record.py
+++ b/edi_queue_oca/models/edi_exchange_record.py
@@ -117,10 +117,15 @@ class EdiExchangeRecord(models.Model):
 
     def _job_on_fail_update(self, failed_state, **kw):
         self.ensure_one()
+        # ``exc_message`` is the first argument of the exception: it is not
+        # always a string (e.g. the errno of an ``OSError``) and may be missing.
+        error = ": ".join(
+            str(kw[k]) for k in ("exc_name", "exc_message") if kw.get(k) is not None
+        )
         self.write(
             {
                 "edi_exchange_state": failed_state,
-                "exchange_error": ": ".join([kw["exc_name"], kw["exc_message"]]),
-                "exchange_error_traceback": kw["exc_info"],
+                "exchange_error": error,
+                "exchange_error_traceback": kw.get("exc_info"),
             }
         )

--- a/edi_queue_oca/tests/test_backend_jobs.py
+++ b/edi_queue_oca/tests/test_backend_jobs.py
@@ -186,3 +186,38 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
             ": ".join([exc_vals["exc_name"], exc_vals["exc_message"]]),
         )
         self.assertEqual(record.exchange_error_traceback, exc_vals["exc_info"])
+
+    def test_on_fail_job_non_string_message(self):
+        # The message is the first argument of the exception, which is the
+        # errno for an OSError, or may be missing altogether.
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        record = self.backend.create_record("test_csv_output", vals)
+        job = record.action_exchange_generate()
+        job.on_fail(
+            {
+                "exc_info": "Dummy traceback",
+                "exc_name": "PermissionError",
+                "exc_message": 13,
+            }
+        )
+        self.assertEqual(record.edi_exchange_state, "validate_error")
+        self.assertEqual(record.exchange_error, "PermissionError: 13")
+        job.on_fail(
+            {
+                "exc_info": "Dummy traceback",
+                "exc_name": "JobFoundDead",
+                "exc_message": None,
+            }
+        )
+        self.assertEqual(record.exchange_error, "JobFoundDead")
+        job.on_fail(
+            {
+                "exc_info": "Dummy traceback",
+                "exc_name": None,
+                "exc_message": "Something went wrong",
+            }
+        )
+        self.assertEqual(record.exchange_error, "Something went wrong")


### PR DESCRIPTION
The hook joins `exc_name` and `exc_message` as strings, but the message stored by queue_job is the first argument of the exception, which is for example the errno for an OSError, and it may also be missing.