### PR TITLE
[18.0] [IMP] edi_party_helper: make endpoint category configurable + use scheme + ease attributes override

### DIFF
--- a/edi_party_helper_oca/models/edi_exchange_type.py
+++ b/edi_party_helper_oca/models/edi_exchange_type.py
@@ -13,3 +13,9 @@ class EDIExchangeType(models.Model):
         comodel_name="res.partner.id_category",
         help="Allowed ID categories to be used to generate parties information.",
     )
+    endpoint_partner_category_id = fields.Many2one(
+        string="Endpoint ID category",
+        comodel_name="res.partner.id_category",
+        help="ID category whose id_number is used as the party's "
+        "`EndpointID` (only meaningful for output exchanges).",
+    )

--- a/edi_party_helper_oca/tests/test_party_helper.py
+++ b/edi_party_helper_oca/tests/test_party_helper.py
@@ -2,6 +2,8 @@
 # @author: Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tools import safe_eval
+
 from ..utils import EDIParty
 from .common import PartyHelperCommonTestCase
 
@@ -81,6 +83,81 @@ class PartyDataHelperTestCase(PartyHelperCommonTestCase):
             party.lang,
             {"name": "English (US)", "code": "en_US", "short": "en"},
         )
+
+    def test_endpoint_manual_override(self):
+        # No `endpoint_partner_category_id` -> `endpoint` falsy by default.
+        party = self._get_party(self.partner1)
+        self.assertFalse(party.endpoint)
+        # `EDIParty` is a `MutableMapping`: item assignment and `.update()`
+        # both work, and keep the `.endpoint` attribute in sync.
+        endpoint = {"attrs": {"schemeID": "0088"}, "value": "7300070011115"}
+        party["endpoint"] = endpoint
+        self.assertEqual(party.endpoint, endpoint)
+        party.update(endpoint={"attrs": {"schemeID": "0088"}, "value": "other"})
+        self.assertEqual(
+            party.endpoint, {"attrs": {"schemeID": "0088"}, "value": "other"}
+        )
+        # Item deletion isn't supported.
+        with self.assertRaises(TypeError):
+            del party["endpoint"]
+
+    def test_endpoint_override_from_safe_eval(self):
+        # This is the actual point of supporting item assignment: plain
+        # attribute assignment (`party.endpoint = ...`) is a forbidden
+        # opcode (`STORE_ATTR`) under `safe_eval` - e.g. from an
+        # `edi.exchange.template.output` `code_snippet` - but item
+        # assignment (`STORE_SUBSCR`) isn't, so `party['endpoint'] = ...`
+        # works from there too.
+        party = self._get_party(self.partner1)
+        endpoint = {"attrs": {"schemeID": "0088"}, "value": "7300070011115"}
+        safe_eval.safe_eval(
+            "party['endpoint'] = endpoint",
+            {"party": party, "endpoint": endpoint},
+            mode="exec",
+            nocopy=True,
+        )
+        self.assertEqual(party.endpoint, endpoint)
+        with self.assertRaises(ValueError):
+            safe_eval.safe_eval(
+                "party.endpoint = endpoint",
+                {"party": party, "endpoint": endpoint},
+                mode="exec",
+                nocopy=True,
+            )
+
+    def test_endpoint_from_category(self):
+        # No `endpoint_partner_category_id` configured -> falsy, even though
+        # the partner has matching id_numbers.
+        party = self._get_party(self.partner1)
+        self.assertFalse(party.endpoint)
+        # Configured -> derived from that category's id_number, schemeID
+        # falling back to `code` (no `scheme` set here).
+        self.exc_type.endpoint_partner_category_id = self.category1
+        party = self._get_party(self.partner1)
+        self.assertEqual(
+            party.endpoint,
+            {"attrs": {"schemeID": "cat1"}, "value": "cat1-p1"},
+        )
+        # With `scheme` set on the category, it's used instead of `code`.
+        self.category1.scheme = "0088"
+        party = self._get_party(self.partner1)
+        self.assertEqual(
+            party.endpoint,
+            {"attrs": {"schemeID": "0088"}, "value": "cat1-p1"},
+        )
+        # Partner has no id_number in the configured category -> falsy.
+        self.exc_type.endpoint_partner_category_id = self.category1
+        party = self._get_party(self.partner3)
+        self.assertFalse(party.endpoint)
+
+    def test_identifier_scheme_override(self):
+        # No `scheme` set on the category -> schemeID falls back to `code`
+        # (this is what cat1/cat2/cat3 already exercise in test_data).
+        # With `scheme` set, it's used instead of `code`.
+        self.category1.scheme = "0088"
+        party = self._get_party(self.partner1)
+        cat1_identifier = [i for i in party.identifiers if i.value == "cat1-p1"][0]
+        self.assertEqual(cat1_identifier.attrs["schemeID"], "0088")
 
     def test_partner_in_party_data(self):
         party = self._get_party(self.partner1)

--- a/edi_party_helper_oca/tests/test_party_helper_model.py
+++ b/edi_party_helper_oca/tests/test_party_helper_model.py
@@ -28,3 +28,13 @@ class PartyHelperModelTestCase(PartyHelperCommonTestCase):
         expected = self._make_expected_data(self.partner2, 2, allowed_codes=["cat2"])
         party = self._get_party(self.partner2)
         self.assertEqual(party, expected)
+
+    def test_data_endpoint_from_category(self):
+        self.exc_type.endpoint_partner_category_id = self.category1
+        expected = self._make_expected_data(
+            self.partner1,
+            1,
+            endpoint={"attrs": {"schemeID": "cat1"}, "value": "cat1-p1"},
+        )
+        party = self._get_party(self.partner1)
+        self.assertEqual(party, expected)

--- a/edi_party_helper_oca/utils.py
+++ b/edi_party_helper_oca/utils.py
@@ -2,22 +2,34 @@
 # @author: Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 
 from odoo.tools import DotDict
 
 
 @dataclass(eq=False)
-class EDIParty(Mapping):
+class EDIParty(MutableMapping):
     """Party information for an EDI exchange.
 
     The instance itself *is* the party: `name`, `identifiers`, `endpoint`
     and `lang` are computed on init and exposed as plain attributes,
-    alongside `partner`. It also behaves like a read-only mapping of those
+    alongside `partner`. It also behaves like a mutable mapping of those
     (eg: ``party["name"]``, ``dict(party)``, equality against a plain dict)
     for backward compatibility with code expecting the old
     ``DotDict``-based party data.
+
+    `name_field` and `lang_code` are constructor-only overrides for their
+    respective computed attributes (`name`, `lang`). `endpoint` is derived
+    from the exchange type's `endpoint_partner_category_id` (an id_number in
+    that category, rendered with its `scheme`/`code`) when set. To force a
+    different value, use ``party["endpoint"] = ...`` or
+    ``party.update(endpoint=...)`` rather than plain attribute assignment
+    (``party.endpoint = ...``) - the latter is a forbidden opcode
+    (`STORE_ATTR`) under `safe_eval`, so it doesn't work from a restricted
+    context like an `edi.exchange.template.output` `code_snippet`; item
+    assignment (`STORE_SUBSCR`) does, and is exactly what `safe_eval`
+    reserves for this (see its own comment on why `STORE_ATTR` is blocked).
     """
 
     exchange_record: object
@@ -27,7 +39,12 @@ class EDIParty(Mapping):
     #: constructor/config attributes, not part of the party data itself:
     #: excluded from the Mapping interface (dict-like access / equality).
     _non_party_attrs = frozenset(
-        {"exchange_record", "name_field", "lang_code", "allowed_id_categories"}
+        {
+            "exchange_record",
+            "name_field",
+            "lang_code",
+            "allowed_id_categories",
+        }
     )
 
     def __post_init__(self):
@@ -50,6 +67,14 @@ class EDIParty(Mapping):
         if key in self._non_party_attrs or key not in vars(self):
             raise KeyError(key)
         return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        if key in self._non_party_attrs:
+            raise KeyError(key)
+        setattr(self, key, value)
+
+    def __delitem__(self, key):
+        raise TypeError(f"{type(self).__name__} does not support item deletion")
 
     def __iter__(self):
         return iter(self._party_data_keys())

--- a/edi_party_helper_oca/utils.py
+++ b/edi_party_helper_oca/utils.py
@@ -61,7 +61,13 @@ class EDIParty(Mapping):
         return self.partner[self.name_field]
 
     def _get_endpoint(self):
-        return {}
+        category = self.exchange_record.type_id.endpoint_partner_category_id
+        if not category:
+            return {}
+        id_number = self.partner.id_numbers.filtered(
+            lambda x: x.category_id == category
+        )[:1]
+        return self._get_identity(id_number) if id_number else {}
 
     def _get_identifiers(self):
         identifiers = self.partner.id_numbers.filtered(
@@ -75,9 +81,10 @@ class EDIParty(Mapping):
         return True
 
     def _get_identity(self, id_number):
+        category = id_number.category_id
         return DotDict(
             attrs={
-                "schemeID": id_number.category_id.code,
+                "schemeID": category.scheme or category.code,
             },
             value=id_number.name,
         )

--- a/edi_party_helper_oca/views/edi_exchange_type_views.xml
+++ b/edi_party_helper_oca/views/edi_exchange_type_views.xml
@@ -7,6 +7,10 @@
             <group name="config" position="after">
                 <group name="party_config">
                     <field name="id_category_ids" widget="many2many_tags" />
+                    <field
+                        name="endpoint_partner_category_id"
+                        invisible="direction != 'output'"
+                    />
                 </group>
             </group>
         </field>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 odoo-test-helper
 xmlunittest
+
+odoo-addon-partner_identification @ git+https://github.com/OCA/partner-contact@refs/pull/2431/head#subdirectory=partner_identification


### PR DESCRIPTION
Depends on
- https://github.com/OCA/partner-contact/pull/2431