### PR TITLE
[19.0] [IMP] edi_exchange_deduplicate_oca: deduplicate on reception

### DIFF
--- a/edi_exchange_deduplicate_oca/README.rst
+++ b/edi_exchange_deduplicate_oca/README.rst
@@ -32,11 +32,14 @@ Edi Exchange Deduplicate OCA
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds options for deduplication records before sending step
-on type:
+This module adds options for deduplication of exchange records on the
+exchange type:
 
-- deduplicate_on_send: check if a fresher one does not exist for the
-  same record. If so, mark the oldest one as obsolete.
+- deduplicate_on_exchange: when a record is created, check if older
+  records for the same record are still pending. If so, mark them as
+  obsolete, so only the freshest one is sent or processed. Records
+  without a related record match on the exchange type alone, which suits
+  full-dump payloads where only the latest one matters.
 - delete_obsolete_records: Delete records marked as obsolete.
 
 **Table of contents**
@@ -49,16 +52,18 @@ Configuration
 
 Go to "EDI -> Config -> Exchange Type".
 
-Enable "Deduplicate on Send" option -> Enable "Delete obsolete records"
-option.
+Enable "Deduplicate on Exchange" option -> Enable "Delete obsolete
+records" option.
 
 Usage
 =====
 
-With all the types that have been enabled "Deduplicate on Send" option,
-this module will check their records if a fresher one does not exist for
-the same record. If so, mark the oldest one as obsolete (except
-"block_obsolescence" records)
+With all the types that have been enabled "Deduplicate on Exchange"
+option, this module will check, when a record is created, if older
+records for the same record (or for the same type, when no record is
+linked) are still pending. If so, mark them as obsolete (except
+"block_obsolescence" records). An obsolete record is neither sent nor
+processed: its job does nothing.
 
 - "block_obsolescence" is an technical option on records to avoid
   marking them as obsolete.

--- a/edi_exchange_deduplicate_oca/__manifest__.py
+++ b/edi_exchange_deduplicate_oca/__manifest__.py
@@ -4,8 +4,8 @@
 {
     "name": "Edi Exchange Deduplicate OCA",
     "summary": """
-        Introduce a deduplication mechanism at the sending step""",
-    "version": "19.0.1.1.1",
+        Mark superseded exchange records as obsolete""",
+    "version": "19.0.2.0.0",
     "license": "LGPL-3",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "maintainers": ["simahawk", "etobella"],

--- a/edi_exchange_deduplicate_oca/migrations/19.0.2.0.0/pre-migration.py
+++ b/edi_exchange_deduplicate_oca/migrations/19.0.2.0.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Camptocamp
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.tools.sql import column_exists, rename_column
+
+
+def migrate(cr, version):
+    # ``deduplicate_on_send`` became a related alias of the new
+    # ``deduplicate_on_exchange``: carry the configured value over.
+    if column_exists(cr, "edi_exchange_type", "deduplicate_on_send") and not (
+        column_exists(cr, "edi_exchange_type", "deduplicate_on_exchange")
+    ):
+        rename_column(
+            cr, "edi_exchange_type", "deduplicate_on_send", "deduplicate_on_exchange"
+        )

--- a/edi_exchange_deduplicate_oca/models/edi_exchange_record.py
+++ b/edi_exchange_deduplicate_oca/models/edi_exchange_record.py
@@ -29,10 +29,7 @@ class EDIExchangeRecord(models.Model):
     def create(self, vals_list):
         records = super().create(vals_list)
         for rec in records:
-            check_obsoleted_record = (
-                rec.type_id.direction == "output" and rec.type_id.deduplicate_on_send
-            )
-            if check_obsoleted_record:
+            if rec.type_id.deduplicate_on_exchange:
                 obsoleted_records = rec._edi_get_duplicates()
                 if obsoleted_records:
                     obsoleted_records.edi_exchange_state = "obsolete"

--- a/edi_exchange_deduplicate_oca/models/edi_exchange_type.py
+++ b/edi_exchange_deduplicate_oca/models/edi_exchange_type.py
@@ -1,18 +1,34 @@
 # Copyright 2024 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class EDIExchangeType(models.Model):
     _inherit = "edi.exchange.type"
 
+    deduplicate_on_exchange = fields.Boolean(
+        string="Deduplicate on Exchange",
+        default=False,
+        help="When an exchange record is created, mark the older ones for the "
+        "same record that are still pending as obsolete, so only the freshest "
+        "one is sent or processed. Records without a related record match on "
+        "the exchange type alone, which suits full-dump payloads where only "
+        "the latest one matters.",
+    )
+    # Kept for backwards compatibility.
+    # TODO: Remove this alias in 20.0 migration
     deduplicate_on_send = fields.Boolean(
         string="Deduplicate on Send",
-        default=False,
-        help="Before sending an exchange record, check if a fresher one does not "
-        "exist for same record; if so, mark oldest one as obsolete.",
+        compute="_compute_deduplicate_on_send",
+        inverse="_inverse_deduplicate_on_send",
+        search="_search_deduplicate_on_send",
+        help="Deprecated: alias of 'Deduplicate on Exchange'.",
     )
     delete_obsolete_records = fields.Boolean(
         string="Delete obsolete records",
@@ -21,9 +37,26 @@ class EDIExchangeType(models.Model):
     )
 
     deduplicate_on_exchange_record_status = fields.Char(
-        default="new,output_pending",
+        default="new,output_pending,input_pending,input_received",
         groups="base.group_no_one",
     )
+
+    @api.depends("deduplicate_on_exchange")
+    def _compute_deduplicate_on_send(self):
+        for rec in self:
+            rec.deduplicate_on_send = rec.deduplicate_on_exchange
+
+    def _inverse_deduplicate_on_send(self):
+        _logger.warning(
+            "'deduplicate_on_send' is deprecated on edi.exchange.type %s, "
+            "use 'deduplicate_on_exchange' instead.",
+            ", ".join(self.mapped("code")),
+        )
+        for rec in self:
+            rec.deduplicate_on_exchange = rec.deduplicate_on_send
+
+    def _search_deduplicate_on_send(self, operator, value):
+        return [("deduplicate_on_exchange", operator, value)]
 
     def _deduplicate_get_exchange_record_states(self):
         self.ensure_one()

--- a/edi_exchange_deduplicate_oca/readme/CONFIGURE.md
+++ b/edi_exchange_deduplicate_oca/readme/CONFIGURE.md
@@ -1,4 +1,4 @@
 Go to "EDI -\> Config -\> Exchange Type".
 
-Enable "Deduplicate on Send" option -\> Enable "Delete obsolete records"
+Enable "Deduplicate on Exchange" option -\> Enable "Delete obsolete records"
 option.

--- a/edi_exchange_deduplicate_oca/readme/DESCRIPTION.md
+++ b/edi_exchange_deduplicate_oca/readme/DESCRIPTION.md
@@ -1,4 +1,8 @@
-This module adds options for deduplication records before sending step on type:  
-- deduplicate_on_send: check if a fresher one does not exist for the
-  same record. If so, mark the oldest one as obsolete.
+This module adds options for deduplication of exchange records on the exchange type:
+
+- deduplicate_on_exchange: when a record is created, check if older records for
+  the same record are still pending. If so, mark them as obsolete, so only the
+  freshest one is sent or processed. Records without a related record match on
+  the exchange type alone, which suits full-dump payloads where only the latest
+  one matters.
 - delete_obsolete_records: Delete records marked as obsolete.

--- a/edi_exchange_deduplicate_oca/readme/USAGE.md
+++ b/edi_exchange_deduplicate_oca/readme/USAGE.md
@@ -1,4 +1,4 @@
-With all the types that have been enabled "Deduplicate on Send" option, this module will check their records if a fresher one does not exist for the same record. If so, mark the oldest one as obsolete (except "block_obsolescence" records)  
+With all the types that have been enabled "Deduplicate on Exchange" option, this module will check, when a record is created, if older records for the same record (or for the same type, when no record is linked) are still pending. If so, mark them as obsolete (except "block_obsolescence" records). An obsolete record is neither sent nor processed: its job does nothing.  
 - "block_obsolescence" is an technical option on records to avoid
   marking them as obsolete.
 - You can restrict deduplication to specific exchange states with the technical field "deduplicate_on_exchange_record_status" (comma-separated values from "edi_exchange_state").

--- a/edi_exchange_deduplicate_oca/static/description/index.html
+++ b/edi_exchange_deduplicate_oca/static/description/index.html
@@ -375,11 +375,14 @@ ul.auto-toc {
 !! source digest: sha256:6826422e9e8075e02643a4a5ab38a5b660013a0899d9642eeccd9b3b25870209
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/edi-framework/tree/19.0/edi_exchange_deduplicate_oca"><img alt="OCA/edi-framework" src="https://img.shields.io/badge/github-OCA%2Fedi--framework-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/edi-framework-19-0/edi-framework-19-0-edi_exchange_deduplicate_oca"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/edi-framework&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module adds options for deduplication records before sending step
-on type:</p>
+<p>This module adds options for deduplication of exchange records on the
+exchange type:</p>
 <ul class="simple">
-<li>deduplicate_on_send: check if a fresher one does not exist for the
-same record. If so, mark the oldest one as obsolete.</li>
+<li>deduplicate_on_exchange: when a record is created, check if older
+records for the same record are still pending. If so, mark them as
+obsolete, so only the freshest one is sent or processed. Records
+without a related record match on the exchange type alone, which suits
+full-dump payloads where only the latest one matters.</li>
 <li>delete_obsolete_records: Delete records marked as obsolete.</li>
 </ul>
 <p><strong>Table of contents</strong></p>
@@ -399,15 +402,17 @@ same record. If so, mark the oldest one as obsolete.</li>
 <div class="section" id="configuration">
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
 <p>Go to “EDI -&gt; Config -&gt; Exchange Type”.</p>
-<p>Enable “Deduplicate on Send” option -&gt; Enable “Delete obsolete records”
-option.</p>
+<p>Enable “Deduplicate on Exchange” option -&gt; Enable “Delete obsolete
+records” option.</p>
 </div>
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-2">Usage</a></h2>
-<p>With all the types that have been enabled “Deduplicate on Send” option,
-this module will check their records if a fresher one does not exist for
-the same record. If so, mark the oldest one as obsolete (except
-“block_obsolescence” records)</p>
+<p>With all the types that have been enabled “Deduplicate on Exchange”
+option, this module will check, when a record is created, if older
+records for the same record (or for the same type, when no record is
+linked) are still pending. If so, mark them as obsolete (except
+“block_obsolescence” records). An obsolete record is neither sent nor
+processed: its job does nothing.</p>
 <ul class="simple">
 <li>“block_obsolescence” is an technical option on records to avoid
 marking them as obsolete.</li>

--- a/edi_exchange_deduplicate_oca/tests/test_deduplicate_on_exchange_record_status.py
+++ b/edi_exchange_deduplicate_oca/tests/test_deduplicate_on_exchange_record_status.py
@@ -39,7 +39,7 @@ class TestDeduplicateOnExchangeRecordStatus(EDIDeduplicateTestCase):
     def test_default_status_deduplicates_new_records(self):
         self.exchange_type_out.write(
             {
-                "deduplicate_on_send": True,
+                "deduplicate_on_exchange": True,
             }
         )
         record1 = self.backend.create_record(
@@ -63,7 +63,7 @@ class TestDeduplicateOnExchangeRecordStatus(EDIDeduplicateTestCase):
     def test_custom_status_filter_is_used_for_deduplication(self):
         self.exchange_type_out.write(
             {
-                "deduplicate_on_send": True,
+                "deduplicate_on_exchange": True,
                 "deduplicate_on_exchange_record_status": "output_pending",
             }
         )

--- a/edi_exchange_deduplicate_oca/tests/test_edi_backend_cron.py
+++ b/edi_exchange_deduplicate_oca/tests/test_edi_backend_cron.py
@@ -14,7 +14,7 @@ class EDIBackendTestCronDeduplicationCase(EDIBackendTestCronCase):
         self.exchange_type_out.write(
             {
                 "exchange_file_auto_generate": True,
-                "deduplicate_on_send": True,
+                "deduplicate_on_exchange": True,
                 "delete_obsolete_records": True,
             }
         )

--- a/edi_exchange_deduplicate_oca/tests/test_edi_duplicate.py
+++ b/edi_exchange_deduplicate_oca/tests/test_edi_duplicate.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Camptocamp
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import base64
+
 from odoo.orm.model_classes import add_to_registry
 from odoo.tools import mute_logger
 
@@ -10,6 +12,7 @@ LOGGERS = (
     "odoo.addons.edi_core_oca.models.edi_backend",
     "odoo.addons.queue_job.delay",
 )
+DEPRECATION_LOGGER = "odoo.addons.edi_exchange_deduplicate_oca.models.edi_exchange_type"
 
 
 class EDIDeduplicateTestCase(EDIBackendCommonTestCase):
@@ -38,12 +41,17 @@ class EDIDeduplicateTestCase(EDIBackendCommonTestCase):
                 "output_validate_model_id": cls.model.id,
             }
         )
+        cls.exchange_type_in.write(
+            {
+                "process_model_id": cls.model.id,
+            }
+        )
 
     @mute_logger(*LOGGERS)
     def test_deduplicate_on_send(self):
         self.exchange_type_out.write(
             {
-                "deduplicate_on_send": True,
+                "deduplicate_on_exchange": True,
             }
         )
         record1 = self.backend.create_record(
@@ -78,7 +86,7 @@ class EDIDeduplicateTestCase(EDIBackendCommonTestCase):
     def test_no_deduplicate_on_send(self):
         self.exchange_type_out.write(
             {
-                "deduplicate_on_send": False,
+                "deduplicate_on_exchange": False,
             }
         )
         record1 = self.backend.create_record(
@@ -112,7 +120,7 @@ class EDIDeduplicateTestCase(EDIBackendCommonTestCase):
     def test_block_obsolescence(self):
         self.exchange_type_out.write(
             {
-                "deduplicate_on_send": True,
+                "deduplicate_on_exchange": True,
             }
         )
         record1 = self.backend.create_record(
@@ -144,3 +152,200 @@ class EDIDeduplicateTestCase(EDIBackendCommonTestCase):
         self.assertEqual(record1.edi_exchange_state, "obsolete")
         self.assertEqual(record2.edi_exchange_state, "output_sent")
         self.assertEqual(record3.edi_exchange_state, "output_sent")
+
+    @mute_logger(*LOGGERS)
+    def test_deduplicate_input_records(self):
+        """Received records without a related record supersede each other.
+
+        Scenario:
+            1. Receive three records of the same input type, none linked to
+               an Odoo record, before any of them is processed.
+            2. Run the input sync.
+        Expected:
+            - The two oldest records are obsolete, the newest one is
+              processed.
+        """
+        self.exchange_type_in.write(
+            {
+                "deduplicate_on_exchange": True,
+            }
+        )
+        record1 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        record2 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        record3 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        # No related record: the newest one supersedes all the pending ones
+        self.assertEqual(record1.edi_exchange_state, "obsolete")
+        self.assertEqual(record2.edi_exchange_state, "obsolete")
+        self.assertEqual(record3.edi_exchange_state, "input_received")
+        self.backend._check_input_exchange_sync()
+        # The obsolete records are skipped, only the last one is processed
+        self.assertEqual(record1.edi_exchange_state, "obsolete")
+        self.assertEqual(record2.edi_exchange_state, "obsolete")
+        self.assertEqual(record3.edi_exchange_state, "input_processed")
+
+    @mute_logger(*LOGGERS)
+    def test_deduplicate_input_records_same_record_only(self):
+        """A received record only supersedes the ones for the same record.
+
+        Scenario:
+            1. Receive a record for partner A, one for partner B, then
+               another one for partner A.
+        Expected:
+            - Only the first record for partner A is obsolete.
+        """
+        self.exchange_type_in.write(
+            {
+                "deduplicate_on_exchange": True,
+            }
+        )
+        other_partner = self.env["res.partner"].create({"name": "EDI EXC OTHER"})
+        record1 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+        record2 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+                "model": other_partner._name,
+                "res_id": other_partner.id,
+            },
+        )
+        record3 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+                "model": self.partner._name,
+                "res_id": self.partner.id,
+            },
+        )
+        self.assertEqual(record1.edi_exchange_state, "obsolete")
+        self.assertEqual(record2.edi_exchange_state, "input_received")
+        self.assertEqual(record3.edi_exchange_state, "input_received")
+
+    @mute_logger(*LOGGERS)
+    def test_deduplicate_input_records_keeps_processed(self):
+        """Processed and failed records are never marked as obsolete.
+
+        Scenario:
+            1. Receive a record and process it.
+            2. Receive a record and have it fail.
+            3. Receive a third record.
+        Expected:
+            - The processed and the failed records keep their state.
+        """
+        self.exchange_type_in.write(
+            {
+                "deduplicate_on_exchange": True,
+            }
+        )
+        record1 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        self.backend._check_input_exchange_sync()
+        self.assertEqual(record1.edi_exchange_state, "input_processed")
+        record2 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        record2.edi_exchange_state = "input_processed_error"
+        self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        self.assertEqual(record1.edi_exchange_state, "input_processed")
+        self.assertEqual(record2.edi_exchange_state, "input_processed_error")
+
+    @mute_logger(*LOGGERS)
+    def test_no_deduplicate_input_records(self):
+        """Without the option, every received record is processed."""
+        record1 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        record2 = self.backend.create_record(
+            "test_csv_input",
+            {
+                "edi_exchange_state": "input_received",
+                "exchange_file": base64.b64encode(b"data"),
+                "exchange_filename": "input.csv",
+            },
+        )
+        self.assertEqual(record1.edi_exchange_state, "input_received")
+        self.assertEqual(record2.edi_exchange_state, "input_received")
+        self.backend._check_input_exchange_sync()
+        self.assertEqual(record1.edi_exchange_state, "input_processed")
+        self.assertEqual(record2.edi_exchange_state, "input_processed")
+
+    def test_deduplicate_on_send_deprecated_alias_on_create(self):
+        """Creating a type with the old flag logs a deprecation warning."""
+        with self.assertLogs(DEPRECATION_LOGGER, level="WARNING") as log:
+            exchange_type = self._create_exchange_type(
+                name="Test CSV deprecated",
+                code="test_csv_deprecated",
+                direction="output",
+                deduplicate_on_send=True,
+            )
+        self.assertIn("deduplicate_on_send' is deprecated", log.output[0])
+        self.assertTrue(exchange_type.deduplicate_on_exchange)
+
+    def test_deduplicate_on_send_deprecated_alias_on_write(self):
+        """The old flag still works, and writing it logs a deprecation warning."""
+        with self.assertLogs(DEPRECATION_LOGGER, level="WARNING") as log:
+            self.exchange_type_out.write({"deduplicate_on_send": True})
+        self.assertIn("deduplicate_on_send' is deprecated", log.output[0])
+        self.assertTrue(self.exchange_type_out.deduplicate_on_exchange)
+        self.assertIn(
+            self.exchange_type_out,
+            self.env["edi.exchange.type"].search([("deduplicate_on_send", "=", True)]),
+        )
+        self.exchange_type_out.deduplicate_on_exchange = False
+        self.assertFalse(self.exchange_type_out.deduplicate_on_send)

--- a/edi_exchange_deduplicate_oca/views/edi_exchange_type_views.xml
+++ b/edi_exchange_deduplicate_oca/views/edi_exchange_type_views.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="edi_core_oca.edi_exchange_type_view_form" />
         <field name="arch" type="xml">
             <field name="allow_empty_files_on_receive" position="after">
-                <field name="deduplicate_on_send" />
+                <field name="deduplicate_on_exchange" />
                 <field
                     name="delete_obsolete_records"
-                    invisible="not deduplicate_on_send"
+                    invisible="not deduplicate_on_exchange"
                 />
             </field>
         </field>


### PR DESCRIPTION
Rename "Deduplicate on Send" to "Deduplicate on Exchange" and apply it to input types too.
The old field stays as a related alias, with a migration.


⚠️ Module version bumped manually for the migration script. Use nobump for merging