### PR TITLE
[FIX] [19.0] edi_core_oca: fix missing kw in super for _search(...)

### DIFF
--- a/edi_core_oca/models/edi_exchange_record.py
+++ b/edi_core_oca/models/edi_exchange_record.py
@@ -576,10 +576,7 @@ class EDIExchangeRecord(models.Model):
 
     def _search(self, domain, offset=0, limit=None, order=None, **kw) -> Query:
         query = super()._search(
-            domain=domain,
-            offset=offset,
-            limit=limit,
-            order=order,
+            domain=domain, offset=offset, limit=limit, order=order, **kw
         )
         if self.env.is_superuser():
             # restrictions do not apply for the superuser


### PR DESCRIPTION
**Issue:**
Missing `**kw` given to the `super` call.

**How to reproduce:**
Generate a edi.exchange.record with a parent and archive this parent.

When you try to open the form view of the child, you will have an `Access Error` because Odoo try to load the parent but as all args are not given to the `super`, the parent is not returned and Odoo perform this as a non-accessible record.

`Fix:`
Just give the `**kw` during call to `super`.

In this case the `kw = {'active_test': False}`

This change comes from Odoo who give this as a parameter in v`19` (it was in the `context` in previous version):
`19`: https://github.com/odoo/odoo/blob/19.0/odoo/orm/models.py#L3802
`18`: https://github.com/odoo/odoo/blob/18.0/odoo/models.py#L4155
