### PR TITLE
[19.0][FIX] edi_core_oca: allow viewing archived exchange records

### DIFF
--- a/edi_core_oca/models/edi_exchange_consumer_mixin.py
+++ b/edi_core_oca/models/edi_exchange_consumer_mixin.py
@@ -259,7 +259,8 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         self.ensure_one()
         xmlid = "edi_core_oca.act_open_edi_exchange_record_view"
         action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
-        action["domain"] = [("id", "in", self.exchange_record_ids.ids)]
+        records = self.with_context(active_test=False).exchange_record_ids
+        action["domain"] = [("id", "in", records.ids)]
         # Purge default search filters from ctx to avoid hiding records
         ctx = action.get("context", {})
         if isinstance(ctx, str):
@@ -267,6 +268,7 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         action["context"] = {
             k: v for k, v in ctx.items() if not k.startswith("search_default_")
         }
+        action["context"]["active_test"] = False
         # Drop ID otherwise the context will be loaded from the action's record :S
         action.pop("id")
         return action

--- a/edi_core_oca/tests/test_consumer_mixin.py
+++ b/edi_core_oca/tests/test_consumer_mixin.py
@@ -106,6 +106,10 @@ result = not record._has_exchange_record(exchange_type, exchange_type.backend_id
                 exchange_record.type_id, self.backend
             )
         )
+        self.assertEqual(action["context"].get("active_test"), False)
+        exchange_record.active = False
+        action = self.consumer_record.action_view_edi_records()
+        self.assertIn(exchange_record.id, action["domain"][0][2])
 
     def test_origin(self):
         vals = {


### PR DESCRIPTION
Avoids ORM AccessError when a specific record ID is requested in an action domain or form view without active_test=False

Odoo also returns archived records in several actions as well:

https://github.com/odoo/odoo/blob/18.0/addons/payment/models/payment_provider.py#L442-L451
https://github.com/odoo/odoo/blob/18.0/addons/crm/models/crm_lost_reason.py#L25-L33